### PR TITLE
Show footer social links on mobile

### DIFF
--- a/frontend/web/src/app/ui/components/Footer.tsx
+++ b/frontend/web/src/app/ui/components/Footer.tsx
@@ -181,7 +181,7 @@ const Credits = styled.p`
   }
 
   ${media.lessThan('medium')`
-    display: none;
+    margin: 20px;
   `}
 `
 
@@ -202,7 +202,7 @@ const SocialList = styled.ul`
   align-items: top;
 
   ${media.lessThan('medium')`
-    display: none;
+    justify-content: center;
   `}
 `
 


### PR DESCRIPTION
On screen sizes under a mobile breakpoint the social (twitter/github/discord) links were hidden. I replaced that styling with some styles to center the icons to match the centered Tadoku logo in the footer.

The "Built by antonve" link was given a similar treatment, but the only change was to make the margins to be symmetrical instead of the bottom margin being twice the top. This looks better in my opinion when everything is closer. The wider breakpoint styles have 0px margins on the left/right sides, but I didn't bother with that here, the text won't wrap unless the viewport is already unreasonably narrow.
                                                                                              
![image](https://user-images.githubusercontent.com/3468630/141702580-c2d11a5b-0262-4eab-984a-286f7d2d388a.png)
