### PR TITLE
Added installing Bazel as a local dev setup step

### DIFF
--- a/docs/local_environment.md
+++ b/docs/local_environment.md
@@ -6,11 +6,12 @@ We use [Tilt](https://tilt.dev/) to spin up a local Kubernetes cluster with all 
 
 ## Getting Started
 
-1. Install Tilt according to their [installation instructions](https://docs.tilt.dev/install.html).
-2. Read the [Getting Started Tutorial](https://docs.tilt.dev/tutorial.html) for Tilt to get familiar with it.
-3. Install [Helm](https://helm.sh/).
-4. Run `$ tilt up` in the root of this repository.
-5. Some services will have a database seed script, these can be manually triggered from within Tilt when needed.
+1. Install [Helm](https://helm.sh/docs/intro/install/).
+2. Install [Bazel](https://docs.bazel.build/bazel-overview.html)
+3. Install [Tilt](https://docs.tilt.dev/install.html).
+4. Read the [Getting Started Tutorial](https://docs.tilt.dev/tutorial.html) for Tilt to get familiar with it.
+5. Run `$ tilt up` in the root of this repository.
+6. Some services will have a database seed script, these can be manually triggered from within Tilt when needed.
 
 ## Can't connect connect to service/database
 

--- a/docs/local_environment.md
+++ b/docs/local_environment.md
@@ -7,7 +7,7 @@ We use [Tilt](https://tilt.dev/) to spin up a local Kubernetes cluster with all 
 ## Getting Started
 
 1. Install [Helm](https://helm.sh/docs/intro/install/).
-2. Install [Bazel](https://docs.bazel.build/bazel-overview.html)
+2. Install [Bazel](https://docs.bazel.build/bazel-overview.html).
 3. Install [Tilt](https://docs.tilt.dev/install.html).
 4. Read the [Getting Started Tutorial](https://docs.tilt.dev/tutorial.html) for Tilt to get familiar with it.
 5. Run `$ tilt up` in the root of this repository.


### PR DESCRIPTION
Bazel is required to build things and needs to be installed, I added it to the docs.

I also rearranged the install instructions to mention installing Helm and Bazel before Tilt, as the Tilt setup is longer and more involved (depending on your OS). During install on another machine I forgot there was anything beyond Tilt and all of its dependencies and had to re-discover that Helm was needed. Putting the quicker to install dependencies first should hopefully prevent me or other people from forgetting them in the future.

I also removed the "according to  their installation instructions" part of the Tilt install step, it seemed redundant, but I can revert it if desired.