### PR TITLE
Renamed database to include the prefix `tadoku-`

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,8 +5,8 @@ load('ext://helm_remote', 'helm_remote')
 
 # Infra
 helm_remote('postgres-operator',
-            repo_name='commonground',
-            repo_url='https://charts.commonground.nl/')
+            repo_name='postgres-operator',
+            repo_url='https://opensource.zalando.com/postgres-operator/charts/postgres-operator/')
 helm_remote('nats',
             repo_name='nats',
             repo_url='https://nats-io.github.io/k8s/helm/charts/',

--- a/docs/local_environment.md
+++ b/docs/local_environment.md
@@ -26,7 +26,7 @@ Given the following database configuration we can derive the connections as foll
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
-  name: reading-contest-api-db
+  name: tadoku-reading-contest-api-db
   labels:
     app: reading-contest-api-db
 spec:
@@ -44,13 +44,13 @@ spec:
 
 ```sh
 # Host, derived from `metadata.name`
-reading-contest-api-db
+tadoku-reading-contest-api-db
 
 # Username, default superuser
 postgres
 
 # Password, secret name has the following pattern: `$username.$database_name.credentials.postgresql.acid.zalan.do`
-$ kubectl get secret postgres.reading-contest-api-db.credentials.postgresql.acid.zalan.do -o json | jq -r .data.password | base64 --decode`
+$ kubectl get secret postgres.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do -o json | jq -r .data.password | base64 --decode`
 
 # Database name, derived from `spec.databases.$database_name`
 tadoku

--- a/services/identity-api/deployments/api.yaml
+++ b/services/identity-api/deployments/api.yaml
@@ -23,20 +23,20 @@ spec:
             - configMapRef:
                 name: identity-api-configmap
             - secretRef:
-                name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
           env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                  name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
                   key: username
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                  name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
                   key: password
             - name: DATABASE_URL
-              value: "postgres://$(username):$(password)@reading-contest-api-db/tadoku"
+              value: "postgres://$(username):$(password)@tadoku-reading-contest-api-db/tadoku"
           readinessProbe:
             httpGet:
               scheme: HTTP

--- a/services/reading-contest-api/deployments/api.yaml
+++ b/services/reading-contest-api/deployments/api.yaml
@@ -22,20 +22,20 @@ spec:
             - configMapRef:
                 name: reading-contest-api-configmap
             - secretRef:
-                name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
           env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                  name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
                   key: username
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+                  name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
                   key: password
             - name: DATABASE_URL
-              value: "postgres://$(username):$(password)@reading-contest-api-db/tadoku"
+              value: "postgres://$(username):$(password)@tadoku-reading-contest-api-db/tadoku"
           readinessProbe:
             httpGet:
               scheme: HTTP
@@ -54,7 +54,7 @@ spec:
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
-  name: reading-contest-api-db
+  name: tadoku-reading-contest-api-db
   labels:
     app: reading-contest-api-db
 spec:

--- a/services/reading-contest-api/deployments/migrate.yaml
+++ b/services/reading-contest-api/deployments/migrate.yaml
@@ -18,17 +18,17 @@ spec:
           - configMapRef:
               name: reading-contest-api-configmap
           - secretRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
         env:
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
               key: username
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
               key: password
         - name: DATABASE_URL
-          value: "postgres://$(username):$(password)@reading-contest-api-db/tadoku"
+          value: "postgres://$(username):$(password)@tadoku-reading-contest-api-db/tadoku"

--- a/services/reading-contest-api/deployments/seed-db.yaml
+++ b/services/reading-contest-api/deployments/seed-db.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: seed-reading-contest-api
         imagePullPolicy: IfNotPresent
-        image: postgres:12
+        image: postgres:13
         command: [ "bin/sh", "-c", "psql -a -f /seed.sql" ]
         volumeMounts:
           - name: seed-sql
@@ -19,20 +19,20 @@ spec:
             subPath: seed.sql
         envFrom:
           - secretRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
         env:
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
               key: username
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: tadoku-user.reading-contest-api-db.credentials.postgresql.acid.zalan.do
+              name: tadoku-user.tadoku-reading-contest-api-db.credentials.postgresql.acid.zalan.do
               key: password
         - name: PGHOST
-          value: reading-contest-api-db
+          value: tadoku-reading-contest-api-db
         - name: PGDATABASE
           value: tadoku
       volumes:


### PR DESCRIPTION
The postgres operator refused to do anything without the `teamId` (`tadoku`) in the database cluster name. Adding this in the operator config name required changes to every other place that used that name so I had a lot of changes in a bunch of places.

The operator error message was:
```
time="2021-11-16T02:25:58Z" level=debug msg="skipping \"ADD\" event for the invalid cluster: name must match {TEAM}-{NAME} format" cluster-name=default/reading-contest-api-db pkg=controller
```

Without that it wouldn't create the database and I was getting lots of errors on the reading-contest-api and identity-api services saying it couldn't find postgres secrets, so that error seemed to be a blocker.

In the meantime (I'm not sure if this contributed to fixing the issue for sure) I changed the source for the postgres operator to use the [official chart](https://github.com/zalando/postgres-operator/blob/master/docs/quickstart.md#helm-chart) which at is using 1.7.1 instead of 1.6.2 like the old one was.

I also updated the postgres version used by the seed db container (it used 12, but the operator is configured to use 13).