### PR TITLE
Show update descriptions on mobile

### DIFF
--- a/frontend/web/src/app/ranking/components/UpdatesList.tsx
+++ b/frontend/web/src/app/ranking/components/UpdatesList.tsx
@@ -5,7 +5,6 @@ import { formatLanguageName, formatMediaDescription } from '../transform/format'
 import { Button, ButtonContainer } from '@app/ui/components'
 import media from 'styled-media-query'
 import Constants from '@app/ui/Constants'
-import { format } from 'date-fns'
 import { formatScore } from '../transform/format'
 import { formatUTC } from '@app/dates'
 

--- a/frontend/web/src/app/ranking/components/UpdatesList.tsx
+++ b/frontend/web/src/app/ranking/components/UpdatesList.tsx
@@ -58,8 +58,14 @@ const UpdatesList = (props: Props) => (
             <strong>{formatScore(l.amount)}</strong> of{' '}
             <strong>{formatMediaDescription(l.mediumId).toLowerCase()}</strong>{' '}
             in <strong>{formatLanguageName(l.languageCode)}</strong> at{' '}
-            <strong>{format(l.date, 'MMM do')}</strong> for a total of{' '}
+            <strong>{formatUTC(l.date, 'MMM do')}</strong> for a total of{' '}
             <strong>{formatScore(l.adjustedAmount)}</strong> points
+            {l.description ? (
+              <>
+                <br />
+                {l.description}
+              </>
+            ) : null}
           </ShowSmallColumn>
           {props.canEdit && (
             <Column style={{ width: '1px', whiteSpace: 'nowrap', padding: 0 }}>


### PR DESCRIPTION
The update description table has a bunch of columns that show or hide based on the viewport width, so the content can differ for mobile and desktop just with CSS. On mobile a single column shows where the content is described in a sentence instead, but it was missing the description and people during the last contest noticed they couldn't see what other people were reading.

I just added the description on a new line below the other update information, as to not crowd the update's sentence format description of the tabular data, as it'd look awkward to have an arbitrarily long description in the middle there. And some people put their own extra information in the description (like mentioning how far through a book/VN they are) so it'd be extra weird in there. So on its own it is!

I also happened to notice that the sentence format for the update wasn't formatting the update day in UTC time, so at mobile breakpoints it was showing "Nov 16th" but at desktop breakpoints it was showing "Nov 17th", so I fixed that too.

I branched this off of (and am targeting) the postgres database renaming changes, as I wasn't able to run Tadoku without that.