### PR TITLE
Easier to understand contest edit form

### DIFF
--- a/frontend/web/src/app/contest/components/forms/ContestForm.tsx
+++ b/frontend/web/src/app/contest/components/forms/ContestForm.tsx
@@ -124,6 +124,7 @@ const ContestForm = ({
             value={description}
             onChange={e => setDescription(e.target.value)}
             error={hasError.description}
+            placeholder="e.g. 2022 Round 1"
           />
           <GroupError
             message="Invalid description"
@@ -156,7 +157,7 @@ const ContestForm = ({
         </Label>
       </Group>
       <Group>
-        <LabelText>Open</LabelText>
+        <LabelText>Open to new participants</LabelText>
         <RadioButton
           type="radio"
           value="false"


### PR DESCRIPTION
The first time I made a round I was a little confused by what "Description" and "Open" meant, so this change aims to make that more obvious.

I added a placeholder on "Description" to make it obvious it's the name of a contest, and as a hint for the format it should take. I also changed the "Open" label to say "Open to new participants" so it's obvious that it only controls whether new people can join the contest, and not whether people can submit updates. This keeps the "Open" keyword so a new admin can make a connection to what the "Open" tag thing means on the rounds table.

(again this is targeting the postgres name change branch because it's the only way  I could get Tadoku to run)