### PR TITLE
Show contest dates in UTC time on the contest management page

### DIFF
--- a/frontend/web/src/app/contest/pages/admin/Manage.tsx
+++ b/frontend/web/src/app/contest/pages/admin/Manage.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react'
 import Link from 'next/link'
-import { format } from 'date-fns'
+import { formatUTC } from '@app/dates'
 import styled from 'styled-components'
 
 import { Contest } from '@app/contest/interfaces'
@@ -129,8 +129,8 @@ const ContestListGroup = ({ contests, editContest }: Props) => (
             {contest.description}
             {contest.open && <OpenTag>Open</OpenTag>}
           </DescriptionCell>
-          <Cell>{format(contest.start, 'MMMM do')}</Cell>
-          <Cell>{format(contest.end, 'MMMM do')}</Cell>
+          <Cell>{formatUTC(contest.start, 'MMMM do')}</Cell>
+          <Cell>{formatUTC(contest.end, 'MMMM do')}</Cell>
           <Cell style={{ width: '1px', whiteSpace: 'nowrap', padding: 0 }}>
             <ActionButtonContainer>
               <Link href={`/contests/${contest.id}/ranking`} passHref>


### PR DESCRIPTION
When viewing contests on the contest management page as an admin the dates were changed to the user's local timezone. When managing a contest that runs off of UTC this is really confusing to confirm if the contest was created for the correct date. This changes the date formatting function in use to show the start and end dates in UTC time.

For example, this is what the contest management screen looks like in prod from UTC -6 (the dates are all shifted a day early)
![image](https://user-images.githubusercontent.com/3468630/143155581-b91b4a43-fa2f-4d66-9551-bae17a8ce161.png)
