### PR TITLE
Updated the node image to 16

### DIFF
--- a/frontend/web/Dockerfile
+++ b/frontend/web/Dockerfile
@@ -1,5 +1,5 @@
 # Install deps
-FROM node:12 AS base
+FROM node:16 AS base
 WORKDIR /base
 COPY . .
 RUN yarn install --frozen-lockfile
@@ -13,7 +13,7 @@ RUN yarn run build
 RUN yarn install --production --ignore-scripts --prefer-offline
 
 # Create production container
-FROM node:12 AS production
+FROM node:16 AS production
 ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=build /build/package.json /build/yarn.lock /build/server.js ./

--- a/frontend/web/Dockerfile.tilt
+++ b/frontend/web/Dockerfile.tilt
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16
 
 WORKDIR /src
 


### PR DESCRIPTION
[Node 12 is EOL starting 2022-04-30](https://nodejs.org/en/about/releases/), this updates the base image for the frontend to 16 which gives us another two years of support.

Closes #332