### PR TITLE
Added a blog post for the 6th round of 2021

### DIFF
--- a/frontend/web/src/app/blog/components/BlogPost.tsx
+++ b/frontend/web/src/app/blog/components/BlogPost.tsx
@@ -24,6 +24,10 @@ const Container = styled.div`
 `
 
 const Content = styled.div`
+  th {
+    font-weight: normal;
+    text-align: left;
+  }
   a {
     color: ${Constants.colors.primary};
     text-decoration: underline;

--- a/services/blog-api/posts-stub.json
+++ b/services/blog-api/posts-stub.json
@@ -1,34 +1,34 @@
 {
-  "posts":[
-     {
-        "title":"Wrap up round 2021.5",
-        "slug":"wrap-up-round-2021-5",
-        "html":"<p>Congrats to <strong>Jazzy</strong> for winning the round with a total score of <strong>9213</strong>! In total <strong>79</strong> people participated in this round for a total score of <strong>78,370.53</strong>.</p> <table> <tr> <td>Japanese</td> <td>76 readers</td> </tr> <tr> <td>English</td> <td>2 readers</td> </tr> <tr> <td>French</td> <td>2 readers</td> </tr> <tr> <td>Portuguese</td> <td>1 reader</td> </tr> <tr> <td>Chinese</td> <td>1 reader</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>Italian</td> <td>1 reader</td> </tr> <tr> <td>German</td> <td>1 reader</td> </tr> </table> <p> I also want to remind everyone to log their pages frequently. This is the first time I've had to remove people and edit logs manually in order to keep things fair for everyone. Don't dump a weeks worth of reading all at once, that kind of behavior is not healthy for the contest. Especially if you're a fast reader you should be logging your pages frequently. Updates of 1000+ pages after days/weeks of silence is demotivating for other participants. From here on out I'll be removing those who dump massive updates infrequently. </p> <p>Thank you all for participating!</p>",
-        "published_at":"2021-10-01T13:47:20.000+00:00"
-     },
-     {
-        "title":"Wrap up round 2021.4",
-        "slug":"wrap-up-round-2021-4",
-        "html":"<p>Congrats to <strong>street神武 天皇</strong> for winning the round with a total score of <strong>6087.6</strong>! In total <strong>93</strong> people participated in this round for a total score of <strong>74,605.06</strong>.</p> <table> <tr> <td>Japanese</td> <td>86 readers</td> </tr> <tr> <td>Chinese</td> <td>3 readers</td> </tr> <tr> <td>Spanish</td> <td>2 readers</td> </tr> <tr> <td>German</td> <td>2 readers</td> </tr> <tr> <td>Latin</td> <td>1 reader</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>English</td> <td>1 reader</td> </tr> <tr> <td>Swedish</td> <td>1 reader</td> </tr> <tr> <td>Italian</td> <td>1 reader</td> </tr> </table> <p>Thank you all for participating!</p>",
-        "published_at":"2021-08-01T13:47:20.000+00:00"
-     },
-     {
-        "title":"Wrap up round 2021.3",
-        "slug":"wrap-up-round-2021-3",
-        "html":"<p>Congrats to <strong>howlongismyname</strong> for winning the round with a total score of <strong>2,270.7</strong>! In total <strong>43</strong> people participated in this round for a total score of <strong>20,253.545</strong>.</p> <table> <tr> <td>Japanese</td> <td>34 readers</td> </tr> <tr> <td>Spanish</td> <td>3 readers</td> </tr> <tr> <td>English</td> <td>2 readers</td> </tr> <tr> <td>Portuguese</td> <td>2 readers</td> </tr> <tr> <td>Chinese</td> <td>2 readers</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>Latin</td> <td>1 reader</td> </tr> <tr> <td>Swedish</td> <td>1 reader</td> </tr> <tr> <td>Croatian</td> <td>1 reader</td> </tr> <tr> <td>Russian</td> <td>1 reader</td> </tr> <tr> <td>German</td> <td>1 reader</td> </tr> </table> <p>Thank you all for participating!</p>",
-        "published_at":"2021-06-13T13:47:20.000+00:00"
-     },
-     {
-        "title":"Wrap up round 2021.2",
-        "slug":"wrap-up-round-2021-2",
-        "html":"<p>Congrats to <strong>Doth</strong> for winning the round with a total score of <strong>12166.5</strong>! This is the first round where the 10k score was broken, by two people nonetheless!<strong> </strong>In total <strong>71</strong> people participated in this round for a total score of <strong>77960.51</strong>.</p><!--kg-card-begin: html--><table>\n    <tr><td>Japanese</td><td>65 readers</td></tr>\n    <tr><td>Chinese</td><td>3 readers</td></tr>\n    <tr><td>English</td><td>2 readers</td></tr>\n    <tr><td>German</td><td>2 readers</td></tr>\n    <tr><td>Latin</td><td>1 reader</td></tr>\n    <tr><td>Swedish</td><td>1 reader</td></tr>\n    <tr><td>Portuguese</td><td>1 reader</td></tr>\n    <tr><td>Spanish</td><td>1 reader</td></tr>\n    <tr><td>French</td><td>1 reader</td></tr>\n    <tr><td>Russian</td><td>1 reader</td></tr>\n    <tr><td>Hebrew</td><td>1 reader</td></tr>\n</table><!--kg-card-end: html--><p>Thank you all for participating!</p>",
-        "published_at":"2021-04-09T13:54:21.000+00:00"
-     },
-     {
-        "title":"Wrap up round 2021.1",
-        "slug":"wrap-up-round-2021-1",
-        "html":"<p>Congrats to <strong>Appolz</strong> for winning the round with a total score of <strong>4401.4</strong>! An impressive score considering they only started learning Japanese in <strong>July 2020. </strong>In total <strong>79</strong> people participated in this round for a total score of <strong>42050.7</strong>.</p><!--kg-card-begin: html--><table>\n    <tr><td>Japanese</td><td>71 readers</td></tr>\n    <tr><td>Spanish</td><td>6 readers</td></tr>\n    <tr><td>Chinese</td><td>3 readers</td></tr>\n    <tr><td>German</td><td>3 readers</td></tr>\n    <tr><td>Dutch</td><td>2 readers</td></tr>\n    <tr><td>French</td><td>1 reader</td></tr>\n    <tr><td>Portuguese</td><td>1 reader</td></tr>\n    <tr><td>Croatian</td><td>1 reader</td></tr>\n    <tr><td>Latin</td><td>1 reader</td></tr>\n    <tr><td>Hebrew</td><td>1 reader</td></tr>\n    <tr><td>English</td><td>1 reader</td></tr>\n    <tr><td>Swedish</td><td>1 reader</td></tr>\n</table><!--kg-card-end: html--><p>Thank you all for participating!</p>",
-        "published_at":"2021-02-03T03:19:06.000+00:00"
-     }
+  "posts": [
+    {
+      "title": "Wrap up round 2021.6",
+      "slug": "wrap-up-round-2021-6",
+      "html": "<p>Congrats to <strong>Socks</strong> for winning the round with a total score of <strong>1591.6</strong>! In total <strong>41</strong> people participated in this round for a total score of <strong>14,234.33</strong>.</p> <table> <tr> <th scope='row'>Japanese</th> <td>37 readers</td> </tr> <tr> <th scope='row'>French</th> <td>2 readers</td> </tr> <tr> <th scope='row'>Hebrew</th> <td>1 reader</td> </tr> <tr> <th scope='row'>Turkish</th> <td>1 reader</td> </tr> <tr> <th scope='row'>Russian</th> <td>1 reader</td> </tr> <tr> <th scope='row'>English</th> <td>1 reader</td> </tr> <tr> <th scope='row'>German</th> <td>1 reader</td> </tr> </table> <p>Thank you all for participating!</p>",
+      "published_at": "2021-11-15T13:47:20.000+00:00"
+    },
+    {
+      "title": "Wrap up round 2021.5",
+      "slug": "wrap-up-round-2021-5",
+      "html": "<p>Congrats to <strong>Jazzy</strong> for winning the round with a total score of <strong>9213</strong>! In total <strong>79</strong> people participated in this round for a total score of <strong>78,370.53</strong>.</p> <table> <tr> <td>Japanese</td> <td>76 readers</td> </tr> <tr> <td>English</td> <td>2 readers</td> </tr> <tr> <td>French</td> <td>2 readers</td> </tr> <tr> <td>Portuguese</td> <td>1 reader</td> </tr> <tr> <td>Chinese</td> <td>1 reader</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>Italian</td> <td>1 reader</td> </tr> <tr> <td>German</td> <td>1 reader</td> </tr> </table> <p> I also want to remind everyone to log their pages frequently. This is the first time I've had to remove people and edit logs manually in order to keep things fair for everyone. Don't dump a weeks worth of reading all at once, that kind of behavior is not healthy for the contest. Especially if you're a fast reader you should be logging your pages frequently. Updates of 1000+ pages after days/weeks of silence is demotivating for other participants. From here on out I'll be removing those who dump massive updates infrequently. </p> <p>Thank you all for participating!</p>",
+      "published_at": "2021-10-01T13:47:20.000+00:00"
+    },
+    {
+      "title": "Wrap up round 2021.4",
+      "slug": "wrap-up-round-2021-4",
+      "html": "<p>Congrats to <strong>street神武 天皇</strong> for winning the round with a total score of <strong>6087.6</strong>! In total <strong>93</strong> people participated in this round for a total score of <strong>74,605.06</strong>.</p> <table> <tr> <td>Japanese</td> <td>86 readers</td> </tr> <tr> <td>Chinese</td> <td>3 readers</td> </tr> <tr> <td>Spanish</td> <td>2 readers</td> </tr> <tr> <td>German</td> <td>2 readers</td> </tr> <tr> <td>Latin</td> <td>1 reader</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>English</td> <td>1 reader</td> </tr> <tr> <td>Swedish</td> <td>1 reader</td> </tr> <tr> <td>Italian</td> <td>1 reader</td> </tr> </table> <p>Thank you all for participating!</p>",
+      "published_at": "2021-08-01T13:47:20.000+00:00"
+    },
+    {
+      "title": "Wrap up round 2021.3",
+      "slug": "wrap-up-round-2021-3",
+      "html": "<p>Congrats to <strong>howlongismyname</strong> for winning the round with a total score of <strong>2,270.7</strong>! In total <strong>43</strong> people participated in this round for a total score of <strong>20,253.545</strong>.</p> <table> <tr> <td>Japanese</td> <td>34 readers</td> </tr> <tr> <td>Spanish</td> <td>3 readers</td> </tr> <tr> <td>English</td> <td>2 readers</td> </tr> <tr> <td>Portuguese</td> <td>2 readers</td> </tr> <tr> <td>Chinese</td> <td>2 readers</td> </tr> <tr> <td>Hebrew</td> <td>1 reader</td> </tr> <tr> <td>Latin</td> <td>1 reader</td> </tr> <tr> <td>Swedish</td> <td>1 reader</td> </tr> <tr> <td>Croatian</td> <td>1 reader</td> </tr> <tr> <td>Russian</td> <td>1 reader</td> </tr> <tr> <td>German</td> <td>1 reader</td> </tr> </table> <p>Thank you all for participating!</p>",
+      "published_at": "2021-06-13T13:47:20.000+00:00"
+    },
+    {
+      "title": "Wrap up round 2021.2",
+      "slug": "wrap-up-round-2021-2",
+      "html": "<p>Congrats to <strong>Doth</strong> for winning the round with a total score of <strong>12166.5</strong>! This is the first round where the 10k score was broken, by two people nonetheless!<strong> </strong>In total <strong>71</strong> people participated in this round for a total score of <strong>77960.51</strong>.</p><!--kg-card-begin: html--><table>\n    <tr><td>Japanese</td><td>65 readers</td></tr>\n    <tr><td>Chinese</td><td>3 readers</td></tr>\n    <tr><td>English</td><td>2 readers</td></tr>\n    <tr><td>German</td><td>2 readers</td></tr>\n    <tr><td>Latin</td><td>1 reader</td></tr>\n    <tr><td>Swedish</td><td>1 reader</td></tr>\n    <tr><td>Portuguese</td><td>1 reader</td></tr>\n    <tr><td>Spanish</td><td>1 reader</td></tr>\n    <tr><td>French</td><td>1 reader</td></tr>\n    <tr><td>Russian</td><td>1 reader</td></tr>\n    <tr><td>Hebrew</td><td>1 reader</td></tr>\n</table><!--kg-card-end: html--><p>Thank you all for participating!</p>",
+      "published_at": "2021-04-09T13:54:21.000+00:00"
+    }
   ]
 }


### PR DESCRIPTION
Deleted the oldest post and added a new one, as seems to be the way things go here.

One minor difference, because the first column in the language table is acting as a header I made them `<th scope=row>` instead, then made them styled the same way the other tables look (disabled the center alignment and bold default styling). I didn't bother doing this for the old posts as it'd be pretty tedious (but if you'd prefer I can do it), and just give it another year and the old posts will work their way out of the blog posts ;)

![image](https://user-images.githubusercontent.com/3468630/144948650-bc0f55fb-382c-4e68-8236-79842e7852e0.png)
