### PR TITLE
Fix user profile update and password changing

### DIFF
--- a/frontend/web/src/app/user/api.ts
+++ b/frontend/web/src/app/user/api.ts
@@ -1,4 +1,6 @@
-import { post } from '../api'
+import { createApiClient } from '../api'
+
+const { post } = createApiClient('identity')
 
 const changePassword = async (
   userId: number,


### PR DESCRIPTION
The default api endpoint exported from `api.ts`'s `post`/`get`/`destroy`/`put` exports is for interacting the contest. The user settings page imports the `post` and tries to use that for user changes, but it should be using the identity service instead. So currently when you try to update your username it posts to `/api/reading-contest/users/2/profile` which obviously 404s.

This change just switches to using the identity api client instead.