### PR TITLE
Don't respond with a null by_language array for stats

### DIFF
--- a/services/reading-contest-api/interfaces/repositories/contest_repository.go
+++ b/services/reading-contest-api/interfaces/repositories/contest_repository.go
@@ -140,7 +140,7 @@ func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
 }
 
 func (r *contestRepository) Stats(id uint64) (domain.ContestStats, error) {
-	var contestStats domain.ContestStats
+	var contestStats domain.ContestStats = domain.ContestStats{ByLanguage: []domain.ContestLanguageStat{}, Participants: 0, TotalAmount: 0}
 
 	_, err := r.FindByID(id)
 


### PR DESCRIPTION
The way I was creating the contest stats struct meant that for contests with no stats the `by_language` array would be `null`. Initializing the struct to some defaults instead of just using `var` to create it seems to fix the issue.

![image](https://user-images.githubusercontent.com/3468630/164000434-1b3f035b-a4c7-42a5-9f71-67d0456c6f27.png)
