### PR TITLE
Fix the leaderboard being wider than the screen when loading

### DIFF
--- a/frontend/web/src/app/ranking/pages/RankingOverview.tsx
+++ b/frontend/web/src/app/ranking/pages/RankingOverview.tsx
@@ -179,7 +179,7 @@ const TwoColumn = styled.div`
 `
 
 const Content = styled.div`
-  flex: 1 0 auto; // enable grow, disable shrink
+  flex: 1 0; // enable grow, disable shrink
 `
 
 const Sidebar = styled.div`


### PR DESCRIPTION
When the ranking is loading and skeletons are shown the rankings were way too wide, so wide the ranking would go off the right edge of the page and the recent updates column would be wrapped below. It seems that removing `flex-basis: auto` from `Content` fixes it. I believe the 100% width on on the Skeleton in Leaderboard.tsx is what was causing issues with the flex basis.

The bug:
![image](https://user-images.githubusercontent.com/3468630/164562726-0d1df261-9a3f-4a5d-8a27-b8f68c56b3c3.png)

The fix:
![image](https://user-images.githubusercontent.com/3468630/164562737-29516559-9ee4-41d8-8411-8e2b96ed12f1.png)
