### PR TITLE
Leaderboard on demand

### DIFF
--- a/services/reading-contest-api/interfaces/repositories/ranking_repository.go
+++ b/services/reading-contest-api/interfaces/repositories/ranking_repository.go
@@ -107,14 +107,14 @@ func (r *rankingRepository) RankingsForContest(
 		)
 
 		select
-			leaderboard.user_id,
-			leaderboard.amount,
+			coalesce(leaderboard.amount, 0) as amount,
+			registrations.user_id,
 			registrations.user_display_name,
 			'GLO' as language_code,
 			$1 as contest_id
 			-- , registrations.language_codes
-		from leaderboard
-		inner join registrations using(user_id)
+		from registrations
+		left join leaderboard using(user_id)
 		order by
 			amount desc,
 			registrations.id asc;

--- a/services/reading-contest-api/interfaces/repositories/ranking_repository.go
+++ b/services/reading-contest-api/interfaces/repositories/ranking_repository.go
@@ -89,7 +89,9 @@ func (r *rankingRepository) RankingsForContest(
 				user_id,
 				sum(weighted_score) as amount
 			from contest_logs
-			where contest_id = $1
+			where
+				contest_id = $1 and
+				deleted_at is null
 			group by user_id
 		), registrations as (
 			select


### PR DESCRIPTION
## Why

Part of the initiative to revamp our leaderboards. Details @ https://github.com/tadoku/tadoku/issues/468

## What

* Removes dependency on pre-calculated rankings, making them effectively a contest registration rather than cached results
* Allows us to add filters to rankings at a later point in time.