### PR TITLE
fixed error in manual.tsx

### DIFF
--- a/frontend/apps/webv2/pages/pages/manual.tsx
+++ b/frontend/apps/webv2/pages/pages/manual.tsx
@@ -95,7 +95,7 @@ const Page: NextPage<Props> = () => (
                 Character{' '}
                 <sup
                   className="text-primary"
-                  title="400 characters per page for Japanese, Chinese, and Korean. 1800 characters per page for all other languages."
+                  title="400 characters per page for Japanese, Chinese, and Korean. 1200 characters per page for all other languages."
                 >
                   2
                 </sup>


### PR DESCRIPTION
the stated multiplier (0.0008333...) which is also the modifier actually used in character to page conversion represents 1200 characters per page, not 1800