### PR TITLE
Add production-parity scoring rule set v2

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0023_platform_scoring_rule_set_v2.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0023_platform_scoring_rule_set_v2.down.sql
@@ -1,0 +1,15 @@
+begin;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 1
+);
+
+delete from scoring_rule_sets
+where scope = 'platform'
+  and version = 2;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0023_platform_scoring_rule_set_v2.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0023_platform_scoring_rule_set_v2.up.sql
@@ -1,0 +1,86 @@
+begin;
+
+insert into scoring_rule_sets (
+  scope,
+  version,
+  status,
+  published_at
+) values (
+  'platform',
+  2,
+  'published',
+  now()
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  score_source,
+  rate
+) select
+  rule_set.id,
+  rule.priority,
+  rule.stackable,
+  rule.activity_id,
+  rule.unit_key,
+  rule.language_code,
+  rule.score_source,
+  rule.rate
+from scoring_rule_sets as rule_set
+cross join (
+  values
+    (100, false, 1, 'reading_two_column_page', 'jpn', 'amount', 1.6),
+    (110, false, 1, 'reading_page', null, 'amount', 1),
+    (120, false, 1, 'reading_comic_page', null, 'amount', 0.2),
+    (130, false, 1, 'reading_sentence', null, 'amount', 0.05),
+    (140, false, 1, 'reading_character', 'jpn', 'amount', 0.0025),
+    (141, false, 1, 'reading_character', 'kor', 'amount', 0.0025),
+    (142, false, 1, 'reading_character', 'zho', 'amount', 0.0025),
+    (143, false, 1, 'reading_character', 'cmn', 'amount', 0.0025),
+    (144, false, 1, 'reading_character', 'yue', 'amount', 0.0025),
+    (145, false, 1, 'reading_character', 'wuu', 'amount', 0.0025),
+    (150, false, 1, 'reading_character', null, 'amount', 0.000833333),
+    (200, false, 2, null, null, 'amount', 0.4),
+    (210, true, 2, 'listening_dense_minutes', null, 'amount', 1.5),
+    (300, false, 3, 'writing_page', null, 'amount', 10),
+    (310, false, 3, 'writing_sentence', null, 'amount', 0.5),
+    (320, false, 3, 'writing_character', 'jpn', 'amount', 0.025),
+    (321, false, 3, 'writing_character', 'kor', 'amount', 0.025),
+    (322, false, 3, 'writing_character', 'zho', 'amount', 0.025),
+    (323, false, 3, 'writing_character', 'cmn', 'amount', 0.025),
+    (324, false, 3, 'writing_character', 'yue', 'amount', 0.025),
+    (325, false, 3, 'writing_character', 'wuu', 'amount', 0.025),
+    (330, false, 3, 'writing_character', null, 'amount', 0.00833333),
+    (400, false, 4, null, null, 'amount', 0.5),
+    (410, true, 4, 'speaking_dense_minutes', null, 'amount', 1.4),
+    (500, false, 5, 'study_minute', null, 'amount', 0.5),
+    (600, false, 1, null, null, 'duration_minutes', 0.2),
+    (610, false, 2, null, null, 'duration_minutes', 0.4),
+    (620, false, 3, null, null, 'duration_minutes', 0.2),
+    (630, false, 4, null, null, 'duration_minutes', 0.5),
+    (640, false, 5, null, null, 'duration_minutes', 0.5)
+) as rule (
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  score_source,
+  rate
+)
+where rule_set.scope = 'platform'
+  and rule_set.version = 2;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 2
+);
+
+commit;


### PR DESCRIPTION
## What changed

- add standalone migration `0023` with immutable platform scoring rule-set v2
- copy the complete 30-rule platform matrix
- change only Writing amount rates to the established production values
- activate v2 while preserving rule-set v1 and historical score snapshots
- provide a down migration that reactivates v1 before removing v2

## Why

Production has intentionally applied boosted Writing rates since 2023, but the original seed data and platform rule-set v1 retained the older 1× values. Shadow scoring therefore evaluated Writing logs at one tenth of their persisted legacy score. The observed 80-character Japanese Writing log persisted 2 points while v1 evaluated 0.2.

This migration restores parity without changing current user-visible scoring, mutating v1, or recalculating historical logs. The authoritative scoring-engine flag remains off.

## Deployment

This is intentionally a migration-only PR. It must be merged and deployed independently before the authoritative scoring-engine rollout continues.

## Validation

- `bazel build //services/immersion-api/storage/postgres/migrations:tar`
- all migrations 0001–0023 applied on disposable PostgreSQL 16
- verified v1 has 30 rules, v2 has 30 rules, and v2 becomes active
- verified down/up round trip reactivates v1 and then restores v2