### PR TITLE
Enable dense duration scoring

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0024_platform_scoring_rule_set_v3_dense_duration.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0024_platform_scoring_rule_set_v3_dense_duration.down.sql
@@ -1,0 +1,15 @@
+begin;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 2
+);
+
+delete from scoring_rule_sets
+where scope = 'platform'
+  and version = 3;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0024_platform_scoring_rule_set_v3_dense_duration.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0024_platform_scoring_rule_set_v3_dense_duration.up.sql
@@ -1,0 +1,76 @@
+begin;
+
+insert into scoring_rule_sets (
+  scope,
+  version,
+  status,
+  published_at
+) values (
+  'platform',
+  3,
+  'published',
+  now()
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+) select
+  (
+    select id
+    from scoring_rule_sets
+    where scope = 'platform'
+      and version = 3
+  ),
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+from scoring_rules
+where rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 2
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  tag,
+  score_source,
+  rate
+) select
+  id,
+  220,
+  true,
+  2,
+  'dense',
+  'duration_minutes',
+  1.5
+from scoring_rule_sets
+where scope = 'platform'
+  and version = 3;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 3
+);
+
+commit;


### PR DESCRIPTION
## Summary

- publish platform scoring rule set v3 as an immutable copy of v2
- add one stackable Listening rule for tag `dense`, source `duration_minutes`, rate 1.5
- atomically activate v3; the down migration reactivates v2 before removing v3

This is a standalone data migration. It does not update logs, stored scores, provenance snapshots, legacy units, or application code.

## Existing `listening_dense_minutes` safety

The existing rule remains priority 210, source `amount`, rate 1.5. The new tag rule is priority 220 and source `duration_minutes`. The evaluator selects exactly one source—and amount wins if both inputs exist—so legacy dense-minute entries cannot match or stack the new modifier.

Regression coverage for this boundary landed separately in #808.

## Verification

- built `//services/immersion-api/storage/postgres/migrations:tar`
- `bazel run //:gazelle -- -mode=diff`
- `bazel build //services/...`
- `bazel test //services/...`
- applied migrations 0001–0024 to disposable Postgres 16
- verified v2 has 30 rules, v3 has 31, and all 30 copied scoring fields have zero differences
- verified priority 210 is amount/legacy dense-minute and priority 220 is duration/tag dense
- verified 0024 down/up round trip: active v2/30 with v3 absent, then active v3/31