### PR TITLE
Add dense Listening common tag

### DIFF
--- a/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
+++ b/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
@@ -21,6 +21,7 @@ const activityTags: Record<number, ActivityTagSuggestion[]> = {
   ],
   // Listening
   2: [
+    { tag: 'dense' },
     { tag: 'audiobook' },
     { tag: 'podcast' },
     { tag: 'anime' },


### PR DESCRIPTION
## Summary

- add `dense` to Listening’s activity-scoped Common tags list
- leave every other activity’s suggestions unchanged
- keep the global autocomplete defaults unchanged, so `dense` is not promoted outside Listening

This makes the newly enabled dense duration scoring easy to select from the V2 logging form.

## Verification

- `pnpm --filter webv2 exec tsc --noEmit`
- `pnpm --filter webv2 lint`
- `pnpm build`