### PR TITLE
Persist latest activity in login v2

### DIFF
--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -21,37 +21,15 @@ import { useSessionOrRedirect } from '@app/common/session'
 import { useEffect } from 'react'
 import { AmountWithUnit, Option, OptionGroup, Select } from 'ui/components/Form'
 import { ScorePreviewEstimate } from '@app/immersion/components/ScorePreviewEstimate'
+import {
+  getLastLoggedActivityId,
+  getLastLoggedLanguage,
+  storeLastLoggedPreferences,
+} from '@app/immersion/NewLogFormV2/preferences'
 
 interface Props {
   options: LogConfigurationOptions
   defaultValues?: Partial<NewLogFormV2Schema>
-}
-
-const LAST_LOGGED_LANGUAGE_STORAGE_KEY = 'log-form-v2:last-logged-language'
-
-const getLastLoggedLanguage = () => {
-  if (typeof window === 'undefined') {
-    return null
-  }
-
-  try {
-    return window.localStorage.getItem(LAST_LOGGED_LANGUAGE_STORAGE_KEY)
-  } catch {
-    return null
-  }
-}
-
-const storeLastLoggedLanguage = (languageCode: string) => {
-  if (typeof window === 'undefined') {
-    return
-  }
-
-  try {
-    window.localStorage.setItem(
-      LAST_LOGGED_LANGUAGE_STORAGE_KEY,
-      languageCode,
-    )
-  } catch {}
 }
 
 export const LogFormV2 = ({
@@ -130,7 +108,7 @@ export const LogFormV2 = ({
 
   const router = useRouter()
   const createLogMutation = useCreateLogV2(log => {
-    storeLastLoggedLanguage(log.language.code)
+    storeLastLoggedPreferences(log.language.code, log.activity.id)
 
     const hasRegistrations =
       registrations.data &&
@@ -152,31 +130,61 @@ export const LogFormV2 = ({
   }
 
   useEffect(() => {
-    if (originalDefaultValues?.languageCode !== undefined) {
+    let restoredLanguageCode = methods.getValues('languageCode')
+    let restoredActivityId = methods.getValues('activityId')
+    let restoredPreference = false
+
+    if (originalDefaultValues?.languageCode === undefined) {
+      const lastLoggedLanguage = getLastLoggedLanguage()
+      if (
+        lastLoggedLanguage !== null &&
+        options.languages.some(
+          language => language.code === lastLoggedLanguage,
+        )
+      ) {
+        restoredLanguageCode = lastLoggedLanguage
+        methods.setValue('languageCode', lastLoggedLanguage)
+        restoredPreference = true
+      }
+    }
+
+    if (originalDefaultValues?.activityId === undefined) {
+      const lastLoggedActivityId = getLastLoggedActivityId(
+        options.activities,
+      )
+      if (lastLoggedActivityId !== null) {
+        restoredActivityId = lastLoggedActivityId
+        methods.setValue('activityId', lastLoggedActivityId)
+        restoredPreference = true
+      }
+    }
+
+    if (!restoredPreference) {
       return
     }
 
-    const lastLoggedLanguage = getLastLoggedLanguage()
-    if (
-      lastLoggedLanguage === null ||
-      !options.languages.some(language => language.code === lastLoggedLanguage)
-    ) {
+    const restoredActivity = options.activities.find(
+      activity => activity.id === restoredActivityId,
+    )
+    if ((restoredActivity?.input_type ?? 'amount_primary') === 'time_primary') {
+      methods.setValue('amountUnit', undefined)
       return
     }
 
-    methods.setValue('languageCode', lastLoggedLanguage)
     methods.setValue(
       'amountUnit',
       filterUnits(
         options.units,
-        methods.getValues('activityId'),
-        lastLoggedLanguage,
+        restoredActivityId,
+        restoredLanguageCode,
       )[0]?.id,
     )
   }, [
     methods,
+    options.activities,
     options.languages,
     options.units,
+    originalDefaultValues?.activityId,
     originalDefaultValues?.languageCode,
   ])
 

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/preferences.test.ts
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/preferences.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getLastLoggedActivityId,
+  storeLastLoggedPreferences,
+  StorageLike,
+} from './preferences'
+
+const createStorage = (initialValues: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initialValues))
+  const storage: StorageLike = {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  }
+
+  return { storage, values }
+}
+
+describe('last logged activity preference', () => {
+  it('restores a stored activity that is still available', () => {
+    const { storage } = createStorage({
+      'log-form-v2:last-logged-activity': '2',
+    })
+
+    expect(getLastLoggedActivityId([{ id: 1 }, { id: 2 }], storage)).toBe(2)
+  })
+
+  it('ignores a stored activity that is no longer available', () => {
+    const { storage } = createStorage({
+      'log-form-v2:last-logged-activity': '3',
+    })
+
+    expect(getLastLoggedActivityId([{ id: 1 }, { id: 2 }], storage)).toBeNull()
+  })
+
+  it('stores the language and activity from the successful log', () => {
+    const { storage, values } = createStorage()
+
+    storeLastLoggedPreferences('jpn', 2, storage)
+
+    expect(values.get('log-form-v2:last-logged-language')).toBe('jpn')
+    expect(values.get('log-form-v2:last-logged-activity')).toBe('2')
+  })
+})

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/preferences.ts
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/preferences.ts
@@ -1,0 +1,62 @@
+const LAST_LOGGED_LANGUAGE_STORAGE_KEY = 'log-form-v2:last-logged-language'
+const LAST_LOGGED_ACTIVITY_STORAGE_KEY = 'log-form-v2:last-logged-activity'
+
+export type StorageLike = Pick<Storage, 'getItem' | 'setItem'>
+
+const getLocalStorage = (): StorageLike | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+export const getLastLoggedLanguage = (
+  storage: StorageLike | undefined = getLocalStorage(),
+) => {
+  try {
+    return storage?.getItem(LAST_LOGGED_LANGUAGE_STORAGE_KEY) ?? null
+  } catch {
+    return null
+  }
+}
+
+export const getLastLoggedActivityId = (
+  activities: ReadonlyArray<{ id: number }>,
+  storage: StorageLike | undefined = getLocalStorage(),
+) => {
+  let storedActivityId: string | null
+  try {
+    storedActivityId =
+      storage?.getItem(LAST_LOGGED_ACTIVITY_STORAGE_KEY) ?? null
+  } catch {
+    return null
+  }
+
+  return (
+    activities.find(activity => activity.id.toString() === storedActivityId)
+      ?.id ?? null
+  )
+}
+
+export const storeLastLoggedPreferences = (
+  languageCode: string,
+  activityId: number,
+  storage: StorageLike | undefined = getLocalStorage(),
+) => {
+  if (storage === undefined) {
+    return
+  }
+
+  try {
+    storage.setItem(LAST_LOGGED_LANGUAGE_STORAGE_KEY, languageCode)
+  } catch {}
+
+  try {
+    storage.setItem(LAST_LOGGED_ACTIVITY_STORAGE_KEY, activityId.toString())
+  } catch {}
+}

--- a/frontend/apps/webv2/package.json
+++ b/frontend/apps/webv2/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",
@@ -46,6 +47,7 @@
     "eslint": "8.29.0",
     "eslint-config-next": "^13.1.1",
     "postcss": "^8.5.23",
-    "tailwindcss": "^3.2.4"
+    "tailwindcss": "^3.2.4",
+    "vitest": "4.1.10"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       tailwindcss:
         specifier: ^3.2.4
         version: 3.4.18
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@18.7.18)(jsdom@27.0.1)(vite@6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1))
 
   packages/paper-ui:
     dependencies:
@@ -1337,9 +1340,6 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1411,6 +1411,7 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-runtime@0.2.9':
     resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
@@ -1477,48 +1478,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@13.5.9':
     resolution: {integrity: sha512-wdQsKsIsGSNdFojvjW3Ozrh8Q00+GqL3wTaMjDkQxVtRbAqfFBtrLPO0IuWChVUP2UeuQcHpVeUvu0YgOP00+g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@13.0.6':
     resolution: {integrity: sha512-/7RF03C3mhjYpHN+pqOolgME3guiHU5T3TsejuyteqyEyzdEyLHod+jcYH6ft7UZ71a6TdOewvmbLOtzHW2O8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-arm64-musl@13.5.9':
     resolution: {integrity: sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@13.0.6':
     resolution: {integrity: sha512-kxyEXnYHpOEkFnmrlwB1QlzJtjC6sAJytKcceIyFUHbCaD3W/Qb5tnclcnHKTaFccizZRePXvV25Ok/eUSpKTw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@13.5.9':
     resolution: {integrity: sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@13.0.6':
     resolution: {integrity: sha512-N0c6gubS3WW1oYYgo02xzZnNatfVQP/CiJq2ax+DJ55ePV62IACbRCU99TZNXXg+Kos6vNW4k+/qgvkvpGDeyA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-musl@13.5.9':
     resolution: {integrity: sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@13.0.6':
     resolution: {integrity: sha512-QjeMB2EBqBFPb/ac0CYr7GytbhUkrG4EwFWbcE0vsRp4H8grt25kYpFQckL4Jak3SUrp7vKfDwZ/SwO7QdO8vw==}
@@ -1659,66 +1668,79 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -2169,41 +2191,49 @@ packages:
     resolution: {integrity: sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.2':
     resolution: {integrity: sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.2':
     resolution: {integrity: sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.2':
     resolution: {integrity: sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.2':
     resolution: {integrity: sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.2':
     resolution: {integrity: sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.2':
     resolution: {integrity: sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.2':
     resolution: {integrity: sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.2':
     resolution: {integrity: sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==}
@@ -5808,13 +5838,13 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/remapping@2.3.5':
@@ -5826,19 +5856,17 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@kurkle/color@0.3.4': {}
 
@@ -6637,6 +6665,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
+  '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1)
+
   '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -7348,7 +7384,7 @@ snapshots:
       eslint: 8.29.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.29.0))(eslint@8.29.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.29.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.29.0))(eslint@8.29.0))(eslint@8.29.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.29.0)
       eslint-plugin-react: 7.37.5(eslint@8.29.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.29.0)
@@ -7378,7 +7414,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.29.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.29.0))(eslint@8.29.0))(eslint@8.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7393,7 +7429,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.29.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.29.0)(typescript@4.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.29.0))(eslint@8.29.0))(eslint@8.29.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9489,8 +9525,8 @@ snapshots:
 
   tinyglobby@0.2.13:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
@@ -9788,6 +9824,20 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
+  vite@6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.23
+      rollup: 4.62.4
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 18.7.18
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.7.1
+
   vite@6.4.3(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.12
@@ -9801,6 +9851,34 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       yaml: 2.7.1
+
+  vitest@4.1.10(@types/node@18.7.18)(jsdom@27.0.1)(vite@6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 6.4.3(@types/node@18.7.18)(jiti@1.21.7)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.7.18
+      jsdom: 27.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@types/node@20.19.25)(jsdom@27.0.1)(vite@6.4.3(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.1)):
     dependencies:


### PR DESCRIPTION
## Summary

- store the selected activity alongside the latest language after a successful login-v2 log submission
- restore the latest available activity when the form loads
- keep the amount unit synchronized with the restored language and activity
- ignore stale activity preferences that are no longer available

## Validation

- `pnpm --filter webv2 test`
- `pnpm --filter webv2 exec tsc --noEmit --incremental false`
- `pnpm --filter webv2 lint`
- `git diff --check`