### PR TITLE
Make the Tilt dev stack deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ The documentation for this repository can be found at https://tadoku.github.io/t
 ## Dev Environment
 
 Use `k8s/dev/` through the root `Tiltfile` for both shared and local clusters.
-Copy `tilt_config.json.example` to `tilt_config.json` for machine-specific hostnames, registries, and contexts.
+Set `TADOKU_TILT_CONFIG` to a machine-level config path so the same config works
+across Git worktrees, or copy `tilt_config.json.example` to the gitignored
+`tilt_config.json` for a checkout-local override. Tilt fails closed when neither
+is configured.
 
 Common commands:
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,8 +2,10 @@
 
 load('./k8s/dev/config/Tiltfile', 'dev_registry', 'is_shared_cluster', 'local_k8s_context', 'shared_k8s_context')
 
-allowed_k8s_contexts = [local_k8s_context]
-if shared_k8s_context != '':
+allowed_k8s_contexts = ['homelab-dev']
+if local_k8s_context not in allowed_k8s_contexts:
+    allowed_k8s_contexts.append(local_k8s_context)
+if shared_k8s_context != '' and shared_k8s_context not in allowed_k8s_contexts:
     allowed_k8s_contexts.append(shared_k8s_context)
 allow_k8s_contexts(allowed_k8s_contexts)
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -16,7 +16,15 @@ We use [Tilt](https://tilt.dev/) to deploy all our backend services & dependenci
 3. Install [Tilt](https://docs.tilt.dev/install.html).
 4. Install [kubectl](https://kubernetes.io/docs/tasks/tools/).
 5. Point kubectl at the cluster you want to use (see below).
-6. Copy `tilt_config.json.example` to `tilt_config.json` and set the local hostnames for your cluster. This file is gitignored.
+6. Create a machine-level config and point `TADOKU_TILT_CONFIG` at it so it is shared by all Git worktrees, or copy `tilt_config.json.example` to the gitignored `tilt_config.json` for a checkout-local override:
+
+   ```sh
+   mkdir -p "$HOME/.config/tadoku"
+   cp tilt_config.json.example "$HOME/.config/tadoku/tilt_config.json"
+   export TADOKU_TILT_CONFIG="$HOME/.config/tadoku/tilt_config.json"
+   ```
+
+   Edit the selected config with the hostnames, registries, and contexts for your cluster. Tilt fails before making cluster changes when the environment variable points to a missing file or neither config source exists. The example file is a template and is never loaded automatically.
 7. Read the [Getting Started Tutorial](https://docs.tilt.dev/tutorial.html) for Tilt to get familiar with it.
 8. Run `$ tilt up` in the root of this repository.
 9. Seed data is applied by the `dev-seed` Tilt resource once the services are up (see below); it can also be re-run manually from within Tilt or via `make dev-seed`.
@@ -50,7 +58,7 @@ For local contexts, backend images are built with Bazel and are not pushed to a 
 
 Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images.
 
-Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over `tilt_config.json`. Shared-cluster mode stays disabled until a shared context is configured via `shared_k8s_context` or `TADOKU_SHARED_K8S_CONTEXT`; there is no committed default.
+Use the machine-level config selected by `TADOKU_TILT_CONFIG`, or copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The explicit config path takes precedence over the checkout-local file. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over values in the selected config. Shared-cluster mode stays disabled until a shared context is configured via `shared_k8s_context` or `TADOKU_SHARED_K8S_CONTEXT`; there is no committed default.
 
 Fetch the dev-cluster kubeconfig after creating `infra/dev/.env.local` from `infra/dev/.env.example`:
 
@@ -95,7 +103,7 @@ make dev-logs    # stream Tilt logs
 
 Seeding (`dev-seed`, also a Tilt resource that runs automatically once the backend services are ready) creates two Kratos identities — an admin `dev@tadoku.app` and a regular user `reader@tadoku.app`, both with password `tadoku` — grants the admin a Keto admin relation, and loads deterministic contests, activity logs, profile, and content data into the `immersion`, `profile`, and `content` databases. The seed is idempotent and safe to re-run: identities created by the seed carry a `seeded_by: tadoku-dev-seed` admin metadata marker, and re-running the seed refreshes their password to the currently configured value, so password overrides take effect on the next `dev-seed`. Identities without the marker (real or manually created accounts) are never modified, even if their email matches. Defaults can be overridden with `TADOKU_DEV_NAMESPACE`, `TADOKU_DEV_DB_PASSWORD`, `TADOKU_DEV_ADMIN_EMAIL`/`TADOKU_DEV_ADMIN_PASSWORD`, and `TADOKU_DEV_READER_EMAIL`/`TADOKU_DEV_READER_PASSWORD`.
 
-Resetting (`dev-reset`, also available as a manual-only `dev-reset` Tilt resource) is destructive: it deletes the Zalando operator-managed `tadoku-dev-db` cluster and its persistent volume claims, reapplies the `postgresql` custom resource, restarts the backend services so their startup migrations run against the fresh database, and then reseeds. The script refuses to run unless the current kubectl context matches a known dev context (`shared_k8s_context`/`local_k8s_context` from `tilt_config.json`, or the `TADOKU_SHARED_K8S_CONTEXT`/`TADOKU_LOCAL_K8S_CONTEXT` env vars), and requires typing the context name to confirm when targeting the shared cluster. Ordinary `tilt down`/`tilt up` keeps data since the database uses persistent volumes.
+Resetting (`dev-reset`, also available as a manual-only `dev-reset` Tilt resource) is destructive: it deletes the Zalando operator-managed `tadoku-dev-db` cluster and its persistent volume claims, reapplies the `postgresql` custom resource, restarts the backend services so their startup migrations run against the fresh database, and then reseeds. The script refuses to run unless the current kubectl context matches a known dev context (`shared_k8s_context`/`local_k8s_context` from the selected Tilt config, or the `TADOKU_SHARED_K8S_CONTEXT`/`TADOKU_LOCAL_K8S_CONTEXT` env vars), and requires typing the context name to confirm when targeting the shared cluster. Ordinary `tilt down`/`tilt up` keeps data since the database uses persistent volumes.
 
 ## Can't connect connect to service/database
 

--- a/frontend/Tiltfile
+++ b/frontend/Tiltfile
@@ -6,6 +6,7 @@ load(
   'is_shared_cluster',
   'render_template',
 )
+load('./../infra/dev/build/Tiltfile', 'anonymous_docker_config_prefix')
 
 def _sh_quote(value):
   return "'" + value.replace("'", "'\"'\"'") + "'"
@@ -19,9 +20,7 @@ def _buildx_output():
 def _buildx_setup_command():
   builder = _sh_quote(dev_buildx_builder())
   return (
-    'TADOKU_FRONTEND_DOCKER_CONFIG="${XDG_CACHE_HOME:-/tmp}/tadoku/frontend-buildx-anonymous"; ' +
-    'mkdir -p "$TADOKU_FRONTEND_DOCKER_CONFIG"; ' +
-    'export DOCKER_CONFIG="$TADOKU_FRONTEND_DOCKER_CONFIG"; ' +
+    anonymous_docker_config_prefix() +
     'docker buildx inspect ' + builder + ' >/dev/null 2>&1 || ' +
     'docker buildx create --name ' + builder + ' --driver docker-container >/dev/null; ' +
     'docker buildx inspect --bootstrap ' + builder + ' >/dev/null; '

--- a/frontend/Tiltfile
+++ b/frontend/Tiltfile
@@ -19,15 +19,17 @@ def _buildx_output():
 def _buildx_setup_command():
   builder = _sh_quote(dev_buildx_builder())
   return (
-    'docker buildx inspect {builder} >/dev/null 2>&1 || ' +
-    'docker buildx create --name {builder} --driver docker-container >/dev/null; ' +
-    'docker buildx inspect --bootstrap {builder} >/dev/null; '
-  ).format(builder=builder)
+    'TADOKU_FRONTEND_DOCKER_CONFIG="${XDG_CACHE_HOME:-/tmp}/tadoku/frontend-buildx-anonymous"; ' +
+    'mkdir -p "$TADOKU_FRONTEND_DOCKER_CONFIG"; ' +
+    'export DOCKER_CONFIG="$TADOKU_FRONTEND_DOCKER_CONFIG"; ' +
+    'docker buildx inspect ' + builder + ' >/dev/null 2>&1 || ' +
+    'docker buildx create --name ' + builder + ' --driver docker-container >/dev/null; ' +
+    'docker buildx inspect --bootstrap ' + builder + ' >/dev/null; '
+  )
 
 def frontend_build(image, project_name, package_trigger, shared_package_manifest='./packages/ui/package.json'):
   if is_shared_cluster():
-    command = (
-      _buildx_setup_command() +
+    command = _buildx_setup_command() + (
       'docker buildx build --builder {builder} --platform {platform} -f ./Dockerfile.dev ' +
       '--build-arg PROJECT_NAME={project_name} ' +
       '--provenance=false --sbom=false ' +

--- a/infra/dev/build/Tiltfile
+++ b/infra/dev/build/Tiltfile
@@ -14,9 +14,8 @@ def _sh_quote(value):
 def anonymous_docker_config_prefix():
   # The shared dev registry accepts anonymous pushes. Isolate both Buildx and
   # Bazel from any developer/admin credentials in the ambient Docker config.
-  # Keep the legacy default directory so existing Buildx metadata is reused.
   return (
-    'TADOKU_DEV_DOCKER_CONFIG="${TADOKU_DEV_DOCKER_CONFIG:-${XDG_CACHE_HOME:-/tmp}/tadoku/frontend-buildx-anonymous}"; ' +
+    'TADOKU_DEV_DOCKER_CONFIG="${TADOKU_DEV_DOCKER_CONFIG:-${XDG_CACHE_HOME:-/tmp}/tadoku/docker-anonymous}"; ' +
     'mkdir -p "$TADOKU_DEV_DOCKER_CONFIG"; ' +
     'export DOCKER_CONFIG="$TADOKU_DEV_DOCKER_CONFIG"; '
   )

--- a/infra/dev/build/Tiltfile
+++ b/infra/dev/build/Tiltfile
@@ -17,6 +17,7 @@ def anonymous_docker_config_prefix():
   return (
     'TADOKU_DEV_DOCKER_CONFIG="${TADOKU_DEV_DOCKER_CONFIG:-${XDG_CACHE_HOME:-/tmp}/tadoku/docker-anonymous}"; ' +
     'mkdir -p "$TADOKU_DEV_DOCKER_CONFIG"; ' +
+    'printf "{}\\n" > "$TADOKU_DEV_DOCKER_CONFIG/config.json"; ' +
     'export DOCKER_CONFIG="$TADOKU_DEV_DOCKER_CONFIG"; '
   )
 

--- a/infra/dev/build/Tiltfile
+++ b/infra/dev/build/Tiltfile
@@ -11,6 +11,16 @@ load(
 def _sh_quote(value):
   return "'" + value.replace("'", "'\"'\"'") + "'"
 
+def anonymous_docker_config_prefix():
+  # The shared dev registry accepts anonymous pushes. Isolate both Buildx and
+  # Bazel from any developer/admin credentials in the ambient Docker config.
+  # Keep the legacy default directory so existing Buildx metadata is reused.
+  return (
+    'TADOKU_DEV_DOCKER_CONFIG="${TADOKU_DEV_DOCKER_CONFIG:-${XDG_CACHE_HOME:-/tmp}/tadoku/frontend-buildx-anonymous}"; ' +
+    'mkdir -p "$TADOKU_DEV_DOCKER_CONFIG"; ' +
+    'export DOCKER_CONFIG="$TADOKU_DEV_DOCKER_CONFIG"; '
+  )
+
 def _local_image_load_command(image_ref):
   if local_cluster_type == 'kind':
     command = 'kind load docker-image'
@@ -30,10 +40,11 @@ def _local_image_load_command(image_ref):
   fail('unsupported local_cluster_type %r; expected kind, minikube, or a daemon-sharing type' % local_cluster_type)
 
 def _bazel_env_prefix():
+  prefix = anonymous_docker_config_prefix()
   ca_file = dev_registry_ca_file()
   if ca_file:
-    return 'SSL_CERT_FILE={ca_file} '.format(ca_file=_sh_quote(ca_file))
-  return ''
+    prefix += 'SSL_CERT_FILE={ca_file} '.format(ca_file=_sh_quote(ca_file))
+  return prefix
 
 def bazel_build(image, target, deps):
   dest = target.replace('//', 'bazel/').replace(':load', ":latest")
@@ -41,8 +52,7 @@ def bazel_build(image, target, deps):
   push_to_registry = is_shared_cluster()
   output_ref_file = ''
   if push_to_registry:
-    command = (
-      _bazel_env_prefix() +
+    command = _bazel_env_prefix() + (
       'bazel run --platforms={bazel_platform} {push_target} -- ' +
       '--repository $EXPECTED_REGISTRY/$EXPECTED_IMAGE --tag $EXPECTED_TAG').format(
         bazel_platform=_sh_quote(dev_bazel_platform()),

--- a/infra/dev/ory/Tiltfile
+++ b/infra/dev/ory/Tiltfile
@@ -17,7 +17,7 @@ helm_resource('kratos',
                 '-f', kratos_values,
               ],
               deps=['./kratos_values.yaml'],
-              resource_deps=['helm-repo-ory', 'tadoku-dev-db'])
+              resource_deps=['helm-repo-ory', 'tadoku-dev-db-ready'])
 
 k8s_resource("kratos", labels=["auth"])
 
@@ -45,7 +45,7 @@ helm_resource('keto',
                 '-f', './keto_values.yaml',
               ],
               deps=['./keto_values.yaml', './namespaces.keto.ts'],
-              resource_deps=['helm-repo-ory', 'tadoku-dev-db'])
+              resource_deps=['helm-repo-ory', 'tadoku-dev-db-ready'])
 
 k8s_resource("keto", labels=["auth"])
 k8s_resource(

--- a/infra/dev/ory/keto_values.yaml
+++ b/infra/dev/ory/keto_values.yaml
@@ -4,7 +4,7 @@ keto:
     type: initContainer
 
   config:
-    dsn: postgres://keto:dev-foobar@tadoku-dev-db:5432/keto?sslmode=require
+    dsn: postgres://keto@tadoku-dev-db:5432/keto?sslmode=require
 
     log:
       level: debug
@@ -36,6 +36,19 @@ service:
     port: 4467
 
 deployment:
+  extraEnv:
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: keto.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+          key: password
+  automigration:
+    extraEnv:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: keto.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+            key: password
   extraVolumes:
     - name: keto-namespaces
       configMap:

--- a/infra/dev/ory/kratos_values.yaml
+++ b/infra/dev/ory/kratos_values.yaml
@@ -2,6 +2,7 @@ kratos:
   development: {{TADOKU_KRATOS_DEVELOPMENT}}
   automigration:
     enabled: true
+    type: initContainer
 
   identitySchemas:
     "identity.default.schema.json": |
@@ -55,7 +56,7 @@ kratos:
 
   # kratos config https://www.ory.sh/docs/kratos/reference/configuration
   config:
-    dsn: postgres://kratos:dev-foobar@tadoku-dev-db:5432/kratos?sslmode=require
+    dsn: postgres://kratos@tadoku-dev-db:5432/kratos?sslmode=require
     secrets:
       default:
         - dev-kratos-default-secret-1
@@ -158,3 +159,18 @@ kratos:
         base_url: "{{TADOKU_AUTH_URL}}/admin/"
         request_log:
           disable_for_health: true
+
+deployment:
+  extraEnv:
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: kratos.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+          key: password
+  automigration:
+    extraEnv:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: kratos.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+            key: password

--- a/infra/dev/tools/Tiltfile
+++ b/infra/dev/tools/Tiltfile
@@ -10,22 +10,5 @@ helm_resource('mailhog',
 k8s_resource("mailhog", labels=["tools"])
 
 # pgweb (postgres client)
-local_resource(
-    "tadoku-dev-db-ready",
-    cmd=[
-        "kubectl",
-        "--context",
-        k8s_context(),
-        "--namespace",
-        "default",
-        "wait",
-        "--for=jsonpath={.status.PostgresClusterStatus}=Running",
-        "postgresql.acid.zalan.do/tadoku-dev-db",
-        "--timeout=300s",
-    ],
-    labels=["tools"],
-    resource_deps=["tadoku-dev-db"],
-)
-
 k8s_yaml('./pgweb.yaml')
 k8s_resource("pgweb", labels=["tools"], resource_deps=["tadoku-dev-db-ready"])

--- a/infra/dev/tools/Tiltfile
+++ b/infra/dev/tools/Tiltfile
@@ -10,5 +10,22 @@ helm_resource('mailhog',
 k8s_resource("mailhog", labels=["tools"])
 
 # pgweb (postgres client)
+local_resource(
+    "tadoku-dev-db-ready",
+    cmd=[
+        "kubectl",
+        "--context",
+        k8s_context(),
+        "--namespace",
+        "default",
+        "wait",
+        "--for=jsonpath={.status.PostgresClusterStatus}=Running",
+        "postgresql.acid.zalan.do/tadoku-dev-db",
+        "--timeout=300s",
+    ],
+    labels=["tools"],
+    resource_deps=["tadoku-dev-db"],
+)
+
 k8s_yaml('./pgweb.yaml')
-k8s_resource("pgweb", labels=["tools"])
+k8s_resource("pgweb", labels=["tools"], resource_deps=["tadoku-dev-db-ready"])

--- a/infra/dev/tools/pgweb.yaml
+++ b/infra/dev/tools/pgweb.yaml
@@ -17,11 +17,38 @@ spec:
       containers:
         - name: pgweb
           image: sosedoff/pgweb
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              escaped_user=$(printf '%s' "$PGUSER" | sed 's/\\/\\\\/g; s/:/\\:/g')
+              escaped_password=$(printf '%s' "$PGPASSWORD" | sed 's/\\/\\\\/g; s/:/\\:/g')
+              printf 'tadoku-dev-db:5432:immersion:%s:%s\n' "$escaped_user" "$escaped_password" > /tmp/pgpass
+              chmod 600 /tmp/pgpass
+              unset PGPASSWORD
+              exec /usr/bin/pgweb \
+                --bind=0.0.0.0 \
+                --listen=8081 \
+                --host=tadoku-dev-db \
+                --port=5432 \
+                --user="$PGUSER" \
+                --db=immersion \
+                --ssl=require \
+                --passfile=/tmp/pgpass
           ports:
             - containerPort: 8081
           env:
-            - name: PGWEB_DATABASE_URL
-              value: "postgres://immersion:dev-foobar@tadoku-dev-db/immersion?sslmode=require"
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: immersion.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immersion.tadoku-dev-db.credentials.postgresql.acid.zalan.do
+                  key: password
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/dev/Tiltfile
+++ b/k8s/dev/Tiltfile
@@ -38,6 +38,10 @@ local_resource(
     resource_deps=['tadoku-dev-db'],
 )
 
+# The Zalando operator creates credentials beside the Postgres resource in
+# default, while each API runs in its own namespace. Copy only the four API
+# credentials after provisioning; the target Namespace owns each copy so Tilt
+# teardown garbage-collects it with the rest of that API's dev resources.
 local_resource(
     'tadoku-dev-db-credentials',
     cmd=[

--- a/k8s/dev/Tiltfile
+++ b/k8s/dev/Tiltfile
@@ -21,6 +21,36 @@ k8s_resource(
     resource_deps=postgres_deps,
 )
 
+local_resource(
+    'tadoku-dev-db-ready',
+    cmd=[
+        'kubectl',
+        '--context',
+        k8s_context(),
+        '--namespace',
+        'default',
+        'wait',
+        '--for=jsonpath={.status.PostgresClusterStatus}=Running',
+        'postgresql.acid.zalan.do/tadoku-dev-db',
+        '--timeout=300s',
+    ],
+    labels=['tools'],
+    resource_deps=['tadoku-dev-db'],
+)
+
+local_resource(
+    'tadoku-dev-db-credentials',
+    cmd=[
+        repo_path('scripts/dev/sync-db-secrets.sh'),
+        k8s_context(),
+    ],
+    deps=[
+        repo_path('scripts/dev/sync-db-secrets.sh'),
+    ],
+    labels=['infra'],
+    resource_deps=['tadoku-dev-db-ready', 'uncategorized'],
+)
+
 ingress_yaml = render_template('k8s/dev/ingress.yaml', '.tilt/rendered/k8s/dev/ingress.yaml')
 k8s_yaml(ingress_yaml)
 k8s_resource(

--- a/k8s/dev/Tiltfile
+++ b/k8s/dev/Tiltfile
@@ -14,12 +14,6 @@ if not is_shared_cluster():
     postgres_deps.append('postgres-operator')
 k8s_resource(
     objects=[
-        'authz.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
-        'content.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
-        'immersion.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
-        'keto.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
-        'kratos.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
-        'profile.tadoku-dev-db.credentials.postgresql.acid.zalan.do:secret:default',
         'tadoku-dev-db:postgresql:default',
     ],
     new_name='tadoku-dev-db',

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -5,10 +5,18 @@ repo_root = os.path.abspath(os.path.join(os.getcwd(), '..', '..', '..'))
 def repo_path(path):
     return os.path.join(repo_root, path)
 
-config_path = repo_path('tilt_config.json')
-user_config_exists = os.path.exists(config_path)
-if not user_config_exists:
-    config_path = repo_path('tilt_config.json.example')
+config_path_env = os.getenv('TADOKU_TILT_CONFIG', '')
+config_path = (
+    os.path.abspath(config_path_env) if config_path_env != '' else
+    repo_path('tilt_config.json')
+)
+if not os.path.exists(config_path):
+    if config_path_env != '':
+        fail('TADOKU_TILT_CONFIG points to a missing file: {}'.format(config_path))
+    fail(
+        'missing Tilt config: set TADOKU_TILT_CONFIG to a shared config path ' +
+        'or copy tilt_config.json.example to tilt_config.json'
+    )
 
 tilt_config = read_json(config_path)
 

--- a/scripts/dev/reset-env.sh
+++ b/scripts/dev/reset-env.sh
@@ -37,13 +37,23 @@ rollout_wait_if_present() {
 
 tilt_config_value() {
   local key="$1"
-  local file
-  for file in "$ROOT/tilt_config.json" "$ROOT/tilt_config.json.example"; do
-    if [ -f "$file" ]; then
-      sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" | head -n 1
-      return 0
+  sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$TILT_CONFIG_PATH" | head -n 1
+}
+
+resolve_tilt_config() {
+  local config_path="${TADOKU_TILT_CONFIG:-$ROOT/tilt_config.json}"
+  if [[ "$config_path" != /* ]]; then
+    config_path="$ROOT/$config_path"
+  fi
+  if [ ! -f "$config_path" ]; then
+    if [ -n "${TADOKU_TILT_CONFIG:-}" ]; then
+      echo "TADOKU_TILT_CONFIG points to a missing file: $config_path" >&2
+    else
+      echo "missing Tilt config: set TADOKU_TILT_CONFIG to a shared config path or copy tilt_config.json.example to tilt_config.json" >&2
     fi
-  done
+    exit 1
+  fi
+  printf '%s\n' "$config_path"
 }
 
 wait_for_db_pod() {
@@ -62,6 +72,7 @@ wait_for_db_pod() {
 }
 
 require_cmd kubectl
+TILT_CONFIG_PATH="$(resolve_tilt_config)"
 
 SHARED_CONTEXT="${TADOKU_SHARED_K8S_CONTEXT:-$(tilt_config_value shared_k8s_context)}"
 SHARED_CONTEXT="${SHARED_CONTEXT:-dev-lab}"

--- a/scripts/dev/reset-env.sh
+++ b/scripts/dev/reset-env.sh
@@ -121,18 +121,20 @@ kubectl -n "$DB_NAMESPACE" wait \
   -l "application=spilo,cluster-name=${DB_NAME}" \
   --timeout=300s
 
+"$ROOT/scripts/dev/sync-db-secrets.sh" "$CURRENT_CONTEXT"
+
 echo "restarting services so startup migrations run against the fresh database..."
 rollout_restart_if_present default kratos
-rollout_restart_if_present default keto-read
-rollout_restart_if_present default keto-write
+rollout_restart_if_present default keto
+rollout_restart_if_present default pgweb
 rollout_restart_if_present tdk-authz-api authz-api
 rollout_restart_if_present tdk-content-api content-api
 rollout_restart_if_present tdk-immersion-api immersion-api
 rollout_restart_if_present tdk-profile-api profile-api
 
 rollout_wait_if_present default kratos
-rollout_wait_if_present default keto-read
-rollout_wait_if_present default keto-write
+rollout_wait_if_present default keto
+rollout_wait_if_present default pgweb
 rollout_wait_if_present tdk-authz-api authz-api
 rollout_wait_if_present tdk-content-api content-api
 rollout_wait_if_present tdk-immersion-api immersion-api

--- a/scripts/dev/seed/immersion.sql
+++ b/scripts/dev/seed/immersion.sql
@@ -134,6 +134,7 @@ insert into logs (
   language_code,
   log_activity_id,
   unit_id,
+  unit_key,
   "description",
   amount,
   modifier,
@@ -150,6 +151,7 @@ values
     'jpn',
     1,
     (select id from log_units where log_activity_id = 1 and name = 'Page' and language_code is null limit 1),
+    (select unit_key from log_units where log_activity_id = 1 and name = 'Page' and language_code is null limit 1),
     'Seeded reading log',
     42,
     1,
@@ -164,6 +166,7 @@ values
     :'reader_user_id'::uuid,
     'jpn',
     2,
+    null,
     null,
     'Seeded listening log',
     null,
@@ -180,6 +183,7 @@ values
     'spa',
     1,
     (select id from log_units where log_activity_id = 1 and name = 'Page' and language_code is null limit 1),
+    (select unit_key from log_units where log_activity_id = 1 and name = 'Page' and language_code is null limit 1),
     'Seeded Spanish reading',
     18,
     1,
@@ -195,6 +199,7 @@ set
   language_code = excluded.language_code,
   log_activity_id = excluded.log_activity_id,
   unit_id = excluded.unit_id,
+  unit_key = excluded.unit_key,
   "description" = excluded."description",
   amount = excluded.amount,
   modifier = excluded.modifier,
@@ -207,17 +212,43 @@ set
 insert into contest_logs (
   contest_id,
   log_id,
+  unit_key,
   amount,
   modifier,
   duration_seconds,
   computed_score
 )
 values
-  ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000301', 42, 1, null, 42),
-  ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000302', null, null, 3600, 30),
-  ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000303', 18, 1, null, 18)
+  (
+    '00000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000301',
+    (select unit_key from logs where id = '00000000-0000-4000-8000-000000000301'),
+    42,
+    1,
+    null,
+    42
+  ),
+  (
+    '00000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000302',
+    (select unit_key from logs where id = '00000000-0000-4000-8000-000000000302'),
+    null,
+    null,
+    3600,
+    30
+  ),
+  (
+    '00000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000303',
+    (select unit_key from logs where id = '00000000-0000-4000-8000-000000000303'),
+    18,
+    1,
+    null,
+    18
+  )
 on conflict (contest_id, log_id) do update
 set
+  unit_key = excluded.unit_key,
   amount = excluded.amount,
   modifier = excluded.modifier,
   duration_seconds = excluded.duration_seconds,

--- a/scripts/dev/sync-db-secrets.sh
+++ b/scripts/dev/sync-db-secrets.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_NAME="tadoku-dev-db"
+DB_NAMESPACE="${TADOKU_DEV_NAMESPACE:-default}"
+KUBECTL_CONTEXT="${1:-}"
+kubectl_args=()
+if [ -n "$KUBECTL_CONTEXT" ]; then
+  kubectl_args+=(--context "$KUBECTL_CONTEXT")
+fi
+
+kube() {
+  kubectl "${kubectl_args[@]}" "$@"
+}
+
+wait_for_secret() {
+  local secret_name="$1"
+  local attempt
+
+  for attempt in $(seq 1 60); do
+    if kube -n "$DB_NAMESPACE" get secret "$secret_name" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "timed out waiting for operator-managed Secret ${DB_NAMESPACE}/${secret_name}" >&2
+  return 1
+}
+
+sync_secret() {
+  local database_user="$1"
+  local target_namespace="$2"
+  local secret_name="${database_user}.${DB_NAME}.credentials.postgresql.acid.zalan.do"
+  local owner_uid
+
+  wait_for_secret "$secret_name"
+
+  owner_uid="$(kube get namespace "$target_namespace" -o jsonpath='{.metadata.uid}')"
+  if [ -z "$owner_uid" ]; then
+    echo "missing target namespace ${target_namespace}" >&2
+    return 1
+  fi
+
+  kube -n "$DB_NAMESPACE" get secret "$secret_name" \
+    -o jsonpath='{.data.username}' | base64 --decode > "$temp_dir/username"
+  kube -n "$DB_NAMESPACE" get secret "$secret_name" \
+    -o jsonpath='{.data.password}' | base64 --decode > "$temp_dir/password"
+
+  kube -n "$target_namespace" create secret generic "$secret_name" \
+    --from-file=username="$temp_dir/username" \
+    --from-file=password="$temp_dir/password" \
+    --dry-run=client \
+    -o yaml | kube apply -f -
+
+  kube -n "$target_namespace" patch secret "$secret_name" \
+    --type=merge \
+    --patch "{\"metadata\":{\"ownerReferences\":[{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"name\":\"${target_namespace}\",\"uid\":\"${owner_uid}\"}]}}" \
+    >/dev/null
+}
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "missing required command: kubectl" >&2
+  exit 1
+fi
+
+if ! command -v base64 >/dev/null 2>&1; then
+  echo "missing required command: base64" >&2
+  exit 1
+fi
+
+umask 077
+temp_dir="$(mktemp -d /tmp/tadoku-db-secrets.XXXXXX)"
+cleanup() {
+  case "$temp_dir" in
+    /tmp/tadoku-db-secrets.*) rm -rf -- "$temp_dir" ;;
+    *) echo "refusing to remove unexpected temporary path: $temp_dir" >&2 ;;
+  esac
+}
+trap cleanup EXIT
+
+sync_secret authz tdk-authz-api
+sync_secret content tdk-content-api
+sync_secret immersion tdk-immersion-api
+sync_secret profile tdk-profile-api

--- a/services/authz-api/Tiltfile
+++ b/services/authz-api/Tiltfile
@@ -9,4 +9,4 @@ bazel_build(
   deps=["./", "./../common/"],
 )
 
-k8s_resource("authz-api", labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto"])
+k8s_resource("authz-api", labels=["backend"], resource_deps=["tadoku-dev-db-credentials", "kratos", "keto"])

--- a/services/content-api/Tiltfile
+++ b/services/content-api/Tiltfile
@@ -10,4 +10,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('content-api', labels=["backend"], resource_deps=["tadoku-dev-db", "keto"])
+k8s_resource('content-api', labels=["backend"], resource_deps=["tadoku-dev-db-credentials", "keto"])

--- a/services/immersion-api/Tiltfile
+++ b/services/immersion-api/Tiltfile
@@ -10,4 +10,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('immersion-api', labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto", "valkey-immersion"])
+k8s_resource('immersion-api', labels=["backend"], resource_deps=["tadoku-dev-db-credentials", "kratos", "keto", "valkey-immersion"])

--- a/services/profile-api/Tiltfile
+++ b/services/profile-api/Tiltfile
@@ -10,4 +10,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('profile-api', labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto"])
+k8s_resource('profile-api', labels=["backend"], resource_deps=["tadoku-dev-db-credentials", "kratos", "keto"])


### PR DESCRIPTION
## Summary

- require explicit durable Tilt configuration and allow the `homelab-dev` context
- make teardown work with operator-managed secrets and use anonymous registry auth for frontend builds
- gate every database consumer on Zalando Postgres readiness and propagate operator credentials into API namespaces
- run Kratos/Keto migrations as init containers, start pgweb only after Postgres, and remove hardcoded database passwords
- restart the actual database consumers during `dev-reset`
- keep immersion seed rows compatible with stable unit-key constraints

## Validation

- evaluated the root Tiltfile for both `homelab-dev` and `orbstack`
- rendered and client-validated the Kratos/Keto charts, pgweb, and all four API manifests
- ran a clean live `homelab-dev` startup: Postgres, Kratos, Keto, pgweb, all frontends, and all four APIs are healthy
- verified Kratos/Keto migrations completed as init containers and no migration Jobs remain
- verified pgweb connected using a passfile and does not retain `PGPASSWORD` in its process environment
- verified copied API credentials match the Zalando operator sources and are owned by their target namespaces
- ran `dev-seed` twice successfully and verified seeded base/contest unit keys
- verified `https://tadoku.dev.lab`, account, admin, and pgweb endpoints
- ran shell syntax checks and `git diff --check`
