### PR TITLE
Fix LogV2 listening score previews

### DIFF
--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -39,8 +39,8 @@ export const EditLogForm = ({ options, log }: Props) => {
   const defaultValues: Partial<NewLogFormV2Schema> = {
     languageCode: log.language.code,
     activityId: log.activity.id,
-    amountValue: log.amount,
-    amountUnit: log.unit_id,
+    amountValue: usesAmountUnit ? log.amount : undefined,
+    amountUnit: usesAmountUnit ? log.unit_id : undefined,
     durationMinutes:
       log.duration_seconds !== undefined
         ? log.duration_seconds / 60

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -167,6 +167,7 @@ export const LogFormV2 = ({
       activity => activity.id === restoredActivityId,
     )
     if ((restoredActivity?.input_type ?? 'amount_primary') === 'time_primary') {
+      methods.setValue('amountValue', undefined)
       methods.setValue('amountUnit', undefined)
       return
     }

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.test.ts
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: { apiEndpoint: '' } }),
+}))
+
+import { NewLogV2APISchema } from './domain'
+
+const amountActivity = {
+  id: 101,
+  name: 'Amount activity',
+  input_type: 'amount_primary' as const,
+}
+const timeActivity = {
+  id: 202,
+  name: 'Time activity',
+  input_type: 'time_primary' as const,
+}
+const amountUnit = {
+  id: 'amount-unit',
+  unit_key: 'test_amount_unit',
+  log_activity_id: amountActivity.id,
+  name: 'Amount unit',
+  modifier: 1,
+}
+const timeUnit = {
+  id: 'time-unit',
+  unit_key: 'test_time_unit',
+  log_activity_id: timeActivity.id,
+  name: 'Time unit',
+  modifier: 0.4,
+}
+
+const validFormValues = {
+  languageCode: 'jpn',
+  allUnits: [amountUnit, timeUnit],
+  allActivities: [amountActivity, timeActivity],
+  tags: [] as string[],
+  description: '',
+}
+
+describe('NewLogV2APISchema', () => {
+  it('ignores a stale zero amount when previewing a duration-only listening log', () => {
+    const result = NewLogV2APISchema.parse({
+      ...validFormValues,
+      activityId: timeActivity.id,
+      amountValue: 0,
+      amountUnit: '00000000-0000-0000-0000-000000000000',
+      durationMinutes: 15,
+    })
+
+    expect(result).toEqual({
+      language_code: 'jpn',
+      activity_id: timeActivity.id,
+      duration_seconds: 900,
+      tags: [],
+      description: '',
+    })
+  })
+
+  it('still rejects a zero amount for an amount-primary activity', () => {
+    const result = NewLogV2APISchema.safeParse({
+      ...validFormValues,
+      activityId: amountActivity.id,
+      amountValue: 0,
+      amountUnit: amountUnit.id,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('still supports a legacy amount-only listening log', () => {
+    const result = NewLogV2APISchema.parse({
+      ...validFormValues,
+      activityId: timeActivity.id,
+      amountValue: 15,
+      amountUnit: timeUnit.id,
+    })
+
+    expect(result).toEqual({
+      language_code: 'jpn',
+      activity_id: timeActivity.id,
+      amount: 15,
+      unit_id: timeUnit.id,
+      tags: [],
+      description: '',
+    })
+  })
+
+  it('rejects a zero amount for a legacy amount-only listening log', () => {
+    const result = NewLogV2APISchema.safeParse({
+      ...validFormValues,
+      activityId: timeActivity.id,
+      amountValue: 0,
+      amountUnit: timeUnit.id,
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
@@ -4,6 +4,12 @@ import { filterUnits } from '@app/immersion/NewLogForm/domain'
 
 export { filterUnits }
 
+const optionalNumber = z.preprocess(
+  value =>
+    typeof value === 'number' && Number.isNaN(value) ? undefined : value,
+  z.number({ invalid_type_error: 'Please enter a number' }).optional(),
+)
+
 const optionalPositiveNumber = z.preprocess(
   value =>
     typeof value === 'number' && Number.isNaN(value) ? undefined : value,
@@ -17,7 +23,7 @@ export const NewLogFormV2Schema = z
   .object({
     languageCode: z.string().length(3, 'invalid language'),
     activityId: z.number(),
-    amountValue: optionalPositiveNumber,
+    amountValue: optionalNumber,
     amountUnit: z.string().optional(),
     durationMinutes: optionalPositiveNumber,
     allUnits: z.array(Unit),
@@ -30,10 +36,12 @@ export const NewLogFormV2Schema = z
     const inputType = activity?.input_type ?? 'amount_primary'
     const unit = log.allUnits.find(it => it.id === log.amountUnit)
     const hasAmount = log.amountValue !== undefined
+    const hasPositiveAmount =
+      log.amountValue !== undefined && log.amountValue > 0
     const hasUnit = log.amountUnit !== undefined && log.amountUnit !== ''
     const hasDuration = log.durationMinutes !== undefined
     const hasValidAmountUnit =
-      hasAmount && hasUnit && unit?.log_activity_id === log.activityId
+      hasPositiveAmount && hasUnit && unit?.log_activity_id === log.activityId
     const durationSeconds = durationSecondsFromMinutes(log.durationMinutes)
 
     if (durationSeconds !== undefined && durationSeconds <= 0) {
@@ -45,7 +53,19 @@ export const NewLogFormV2Schema = z
     }
 
     if (inputType === 'time_primary') {
-      if (!hasDuration && !hasValidAmountUnit) {
+      if (hasDuration) {
+        return
+      }
+
+      if (hasAmount && !hasPositiveAmount) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['amountValue'],
+          message: 'Amount must be greater than 0',
+        })
+      }
+
+      if (!hasValidAmountUnit) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['durationMinutes'],
@@ -60,6 +80,12 @@ export const NewLogFormV2Schema = z
         code: z.ZodIssueCode.custom,
         path: ['amountValue'],
         message: 'Amount is required',
+      })
+    } else if (!hasPositiveAmount) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['amountValue'],
+        message: 'Amount must be greater than 0',
       })
     }
 
@@ -89,6 +115,7 @@ export const NewLogV2APISchema = NewLogFormV2Schema.transform(log => {
   const unit = log.allUnits.find(it => it.id === log.amountUnit)
   const hasValidAmountUnit =
     log.amountValue !== undefined &&
+    log.amountValue > 0 &&
     log.amountUnit !== undefined &&
     log.amountUnit !== '' &&
     unit?.log_activity_id === log.activityId

--- a/frontend/apps/webv2/vitest.config.ts
+++ b/frontend/apps/webv2/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@app': fileURLToPath(new URL('./app', import.meta.url)),
+      '@pages': fileURLToPath(new URL('./pages', import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- initialize duration-only LogV2 forms without stale amount/unit values
- validate amount values according to the selected tracking mode
- add regression coverage for duration and legacy amount-based listening logs

## Testing
- `pnpm --filter webv2 test`
- `pnpm --filter webv2 exec tsc --noEmit`
- `pnpm --filter webv2 lint`
- `pnpm build`

**Posted by gpt-5.6-sol**