### PR TITLE
Validate contest language selections

### DIFF
--- a/services/immersion-api/domain/contestcreate.go
+++ b/services/immersion-api/domain/contestcreate.go
@@ -12,7 +12,7 @@ import (
 
 type ContestCreateRepository interface {
 	GetContestsByUserCountForYear(context.Context, time.Time, uuid.UUID) (int32, error)
-	LanguageExists(context.Context, string) (bool, error)
+	LanguagesExist(context.Context, []string) (bool, error)
 	CreateContest(context.Context, *ContestCreateRequest) (*ContestCreateResponse, error)
 }
 
@@ -122,13 +122,13 @@ func (s *ContestCreate) Execute(ctx context.Context, req *ContestCreateRequest) 
 		}
 	}
 
-	for _, code := range req.LanguageCodeAllowList {
-		exists, err := s.repo.LanguageExists(ctx, code)
+	if len(req.LanguageCodeAllowList) > 0 {
+		exists, err := s.repo.LanguagesExist(ctx, req.LanguageCodeAllowList)
 		if err != nil {
-			return nil, fmt.Errorf("could not check whether language %s exists: %w", code, err)
+			return nil, fmt.Errorf("could not check whether languages exist: %w", err)
 		}
 		if !exists {
-			return nil, fmt.Errorf("language %s does not exist: %w", code, ErrInvalidContest)
+			return nil, fmt.Errorf("one or more languages do not exist: %w", ErrInvalidContest)
 		}
 	}
 

--- a/services/immersion-api/domain/contestcreate.go
+++ b/services/immersion-api/domain/contestcreate.go
@@ -12,6 +12,7 @@ import (
 
 type ContestCreateRepository interface {
 	GetContestsByUserCountForYear(context.Context, time.Time, uuid.UUID) (int32, error)
+	LanguageExists(context.Context, string) (bool, error)
 	CreateContest(context.Context, *ContestCreateRequest) (*ContestCreateResponse, error)
 }
 
@@ -118,6 +119,16 @@ func (s *ContestCreate) Execute(ctx context.Context, req *ContestCreateRequest) 
 	for _, activityID := range req.ActivityTypeIDAllowList {
 		if !IsValidActivityID(activityID) {
 			return nil, fmt.Errorf("activity %d is not valid: %w", activityID, ErrInvalidContest)
+		}
+	}
+
+	for _, code := range req.LanguageCodeAllowList {
+		exists, err := s.repo.LanguageExists(ctx, code)
+		if err != nil {
+			return nil, fmt.Errorf("could not check whether language %s exists: %w", code, err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("language %s does not exist: %w", code, ErrInvalidContest)
 		}
 	}
 

--- a/services/immersion-api/domain/contestcreate_test.go
+++ b/services/immersion-api/domain/contestcreate_test.go
@@ -21,7 +21,7 @@ type mockContestCreateRepository struct {
 	userUpsertCalled  bool
 	languageExists    map[string]bool
 	languageExistsErr error
-	languageLookups   []string
+	languageBatches   [][]string
 }
 
 func (m *mockContestCreateRepository) CreateContest(ctx context.Context, req *domain.ContestCreateRequest) (*domain.ContestCreateResponse, error) {
@@ -38,15 +38,20 @@ func (m *mockContestCreateRepository) UpsertUser(ctx context.Context, req *domai
 	return nil
 }
 
-func (m *mockContestCreateRepository) LanguageExists(_ context.Context, code string) (bool, error) {
-	m.languageLookups = append(m.languageLookups, code)
+func (m *mockContestCreateRepository) LanguagesExist(_ context.Context, codes []string) (bool, error) {
+	m.languageBatches = append(m.languageBatches, append([]string(nil), codes...))
 	if m.languageExistsErr != nil {
 		return false, m.languageExistsErr
 	}
 	if m.languageExists == nil {
 		return true, nil
 	}
-	return m.languageExists[code], nil
+	for _, code := range codes {
+		if !m.languageExists[code] {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func TestContestCreate_Execute(t *testing.T) {
@@ -163,6 +168,7 @@ func TestContestCreate_Execute(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
+		assert.Empty(t, repo.languageBatches)
 		assert.True(t, repo.createCalled)
 	})
 
@@ -202,7 +208,7 @@ func TestContestCreate_Execute(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
-		assert.Equal(t, []string{"jpn", "kor"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn", "kor"}}, repo.languageBatches)
 		assert.True(t, repo.createCalled)
 	})
 
@@ -222,7 +228,7 @@ func TestContestCreate_Execute(t *testing.T) {
 		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
 
 		assert.ErrorIs(t, err, domain.ErrInvalidContest)
-		assert.Equal(t, []string{"invalid"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"invalid"}}, repo.languageBatches)
 		assert.False(t, repo.createCalled)
 	})
 
@@ -242,7 +248,7 @@ func TestContestCreate_Execute(t *testing.T) {
 		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
 
 		assert.ErrorIs(t, err, domain.ErrInvalidContest)
-		assert.Equal(t, []string{"jpn", "invalid"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn", "invalid"}}, repo.languageBatches)
 		assert.False(t, repo.createCalled)
 	})
 
@@ -263,7 +269,7 @@ func TestContestCreate_Execute(t *testing.T) {
 		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
 
 		assert.ErrorIs(t, err, lookupErr)
-		assert.Equal(t, []string{"jpn"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn"}}, repo.languageBatches)
 		assert.False(t, repo.createCalled)
 	})
 }

--- a/services/immersion-api/domain/contestcreate_test.go
+++ b/services/immersion-api/domain/contestcreate_test.go
@@ -2,6 +2,7 @@ package domain_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -12,12 +13,15 @@ import (
 )
 
 type mockContestCreateRepository struct {
-	createCalled     bool
-	createResult     *domain.ContestCreateResponse
-	createErr        error
-	contestCount     int32
-	contestCountErr  error
-	userUpsertCalled bool
+	createCalled      bool
+	createResult      *domain.ContestCreateResponse
+	createErr         error
+	contestCount      int32
+	contestCountErr   error
+	userUpsertCalled  bool
+	languageExists    map[string]bool
+	languageExistsErr error
+	languageLookups   []string
 }
 
 func (m *mockContestCreateRepository) CreateContest(ctx context.Context, req *domain.ContestCreateRequest) (*domain.ContestCreateResponse, error) {
@@ -32,6 +36,17 @@ func (m *mockContestCreateRepository) GetContestsByUserCountForYear(ctx context.
 func (m *mockContestCreateRepository) UpsertUser(ctx context.Context, req *domain.UserUpsertRequest) error {
 	m.userUpsertCalled = true
 	return nil
+}
+
+func (m *mockContestCreateRepository) LanguageExists(_ context.Context, code string) (bool, error) {
+	m.languageLookups = append(m.languageLookups, code)
+	if m.languageExistsErr != nil {
+		return false, m.languageExistsErr
+	}
+	if m.languageExists == nil {
+		return true, nil
+	}
+	return m.languageExists[code], nil
 }
 
 func TestContestCreate_Execute(t *testing.T) {
@@ -163,6 +178,92 @@ func TestContestCreate_Execute(t *testing.T) {
 		_, err := svc.Execute(ctx, validRequest)
 
 		assert.ErrorIs(t, err, domain.ErrForbidden)
+		assert.False(t, repo.createCalled)
+	})
+
+	t.Run("allows known language codes", func(t *testing.T) {
+		expectedResult := &domain.ContestCreateResponse{ID: uuid.New(), Title: "language round"}
+		repo := &mockContestCreateRepository{
+			createResult:   expectedResult,
+			languageExists: map[string]bool{"jpn": true, "kor": true},
+		}
+		userUpsert := domain.NewUserUpsert(repo)
+		svc := domain.NewContestCreate(repo, clock, userUpsert)
+		request := &domain.ContestCreateRequest{
+			ContestStart:            now.Add(30 * 24 * time.Hour),
+			ContestEnd:              now.Add(45 * 24 * time.Hour),
+			RegistrationEnd:         now.Add(40 * 24 * time.Hour),
+			Title:                   "language round",
+			ActivityTypeIDAllowList: []int32{1},
+			LanguageCodeAllowList:   []string{"jpn", "kor"},
+		}
+
+		result, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+		assert.Equal(t, []string{"jpn", "kor"}, repo.languageLookups)
+		assert.True(t, repo.createCalled)
+	})
+
+	t.Run("rejects an unknown language code", func(t *testing.T) {
+		repo := &mockContestCreateRepository{languageExists: map[string]bool{"invalid": false}}
+		userUpsert := domain.NewUserUpsert(repo)
+		svc := domain.NewContestCreate(repo, clock, userUpsert)
+		request := &domain.ContestCreateRequest{
+			ContestStart:            now.Add(30 * 24 * time.Hour),
+			ContestEnd:              now.Add(45 * 24 * time.Hour),
+			RegistrationEnd:         now.Add(40 * 24 * time.Hour),
+			Title:                   "language round",
+			ActivityTypeIDAllowList: []int32{1},
+			LanguageCodeAllowList:   []string{"invalid"},
+		}
+
+		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
+
+		assert.ErrorIs(t, err, domain.ErrInvalidContest)
+		assert.Equal(t, []string{"invalid"}, repo.languageLookups)
+		assert.False(t, repo.createCalled)
+	})
+
+	t.Run("rejects a mixed list containing an unknown language code", func(t *testing.T) {
+		repo := &mockContestCreateRepository{languageExists: map[string]bool{"jpn": true, "invalid": false}}
+		userUpsert := domain.NewUserUpsert(repo)
+		svc := domain.NewContestCreate(repo, clock, userUpsert)
+		request := &domain.ContestCreateRequest{
+			ContestStart:            now.Add(30 * 24 * time.Hour),
+			ContestEnd:              now.Add(45 * 24 * time.Hour),
+			RegistrationEnd:         now.Add(40 * 24 * time.Hour),
+			Title:                   "language round",
+			ActivityTypeIDAllowList: []int32{1},
+			LanguageCodeAllowList:   []string{"jpn", "invalid"},
+		}
+
+		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
+
+		assert.ErrorIs(t, err, domain.ErrInvalidContest)
+		assert.Equal(t, []string{"jpn", "invalid"}, repo.languageLookups)
+		assert.False(t, repo.createCalled)
+	})
+
+	t.Run("returns a language lookup error without creating a contest", func(t *testing.T) {
+		lookupErr := errors.New("language repository unavailable")
+		repo := &mockContestCreateRepository{languageExistsErr: lookupErr}
+		userUpsert := domain.NewUserUpsert(repo)
+		svc := domain.NewContestCreate(repo, clock, userUpsert)
+		request := &domain.ContestCreateRequest{
+			ContestStart:            now.Add(30 * 24 * time.Hour),
+			ContestEnd:              now.Add(45 * 24 * time.Hour),
+			RegistrationEnd:         now.Add(40 * 24 * time.Hour),
+			Title:                   "language round",
+			ActivityTypeIDAllowList: []int32{1},
+			LanguageCodeAllowList:   []string{"jpn"},
+		}
+
+		_, err := svc.Execute(ctxWithUserIdentity(uuid.NewString(), "TestUser"), request)
+
+		assert.ErrorIs(t, err, lookupErr)
+		assert.Equal(t, []string{"jpn"}, repo.languageLookups)
 		assert.False(t, repo.createCalled)
 	})
 }

--- a/services/immersion-api/domain/registrationupsert.go
+++ b/services/immersion-api/domain/registrationupsert.go
@@ -12,7 +12,7 @@ import (
 type RegistrationUpsertRepository interface {
 	FindContestByID(context.Context, *ContestFindRequest) (*ContestView, error)
 	FindRegistrationForUser(context.Context, *RegistrationFindRequest) (*ContestRegistration, error)
-	LanguageExists(context.Context, string) (bool, error)
+	LanguagesExist(context.Context, []string) (bool, error)
 	UpsertContestRegistration(context.Context, *RegistrationUpsertRequest) error
 	DetachContestLogsForLanguages(context.Context, *DetachContestLogsForLanguagesRequest) error
 }
@@ -85,14 +85,12 @@ func (s *RegistrationUpsert) Execute(ctx context.Context, req *RegistrationUpser
 		return fmt.Errorf("invalid language code length: %w", ErrInvalidContestRegistration)
 	}
 
-	for _, code := range req.LanguageCodes {
-		exists, err := s.repo.LanguageExists(ctx, code)
-		if err != nil {
-			return fmt.Errorf("could not check whether language %s exists: %w", code, err)
-		}
-		if !exists {
-			return fmt.Errorf("language %s does not exist: %w", code, ErrInvalidContestRegistration)
-		}
+	exists, err := s.repo.LanguagesExist(ctx, req.LanguageCodes)
+	if err != nil {
+		return fmt.Errorf("could not check whether languages exist: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("one or more languages do not exist: %w", ErrInvalidContestRegistration)
 	}
 
 	// check if languages are allowed by contest

--- a/services/immersion-api/domain/registrationupsert.go
+++ b/services/immersion-api/domain/registrationupsert.go
@@ -12,6 +12,7 @@ import (
 type RegistrationUpsertRepository interface {
 	FindContestByID(context.Context, *ContestFindRequest) (*ContestView, error)
 	FindRegistrationForUser(context.Context, *RegistrationFindRequest) (*ContestRegistration, error)
+	LanguageExists(context.Context, string) (bool, error)
 	UpsertContestRegistration(context.Context, *RegistrationUpsertRequest) error
 	DetachContestLogsForLanguages(context.Context, *DetachContestLogsForLanguagesRequest) error
 }
@@ -82,6 +83,16 @@ func (s *RegistrationUpsert) Execute(ctx context.Context, req *RegistrationUpser
 
 	if len(req.LanguageCodes) < 1 || len(req.LanguageCodes) > 3 {
 		return fmt.Errorf("invalid language code length: %w", ErrInvalidContestRegistration)
+	}
+
+	for _, code := range req.LanguageCodes {
+		exists, err := s.repo.LanguageExists(ctx, code)
+		if err != nil {
+			return fmt.Errorf("could not check whether language %s exists: %w", code, err)
+		}
+		if !exists {
+			return fmt.Errorf("language %s does not exist: %w", code, ErrInvalidContestRegistration)
+		}
 	}
 
 	// check if languages are allowed by contest

--- a/services/immersion-api/domain/registrationupsert_test.go
+++ b/services/immersion-api/domain/registrationupsert_test.go
@@ -26,7 +26,7 @@ type mockRegistrationUpsertRepository struct {
 	detachErr         error
 	languageExists    map[string]bool
 	languageExistsErr error
-	languageLookups   []string
+	languageBatches   [][]string
 }
 
 func (m *mockRegistrationUpsertRepository) FindContestByID(ctx context.Context, req *domain.ContestFindRequest) (*domain.ContestView, error) {
@@ -49,15 +49,20 @@ func (m *mockRegistrationUpsertRepository) DetachContestLogsForLanguages(ctx con
 	return m.detachErr
 }
 
-func (m *mockRegistrationUpsertRepository) LanguageExists(_ context.Context, code string) (bool, error) {
-	m.languageLookups = append(m.languageLookups, code)
+func (m *mockRegistrationUpsertRepository) LanguagesExist(_ context.Context, codes []string) (bool, error) {
+	m.languageBatches = append(m.languageBatches, append([]string(nil), codes...))
 	if m.languageExistsErr != nil {
 		return false, m.languageExistsErr
 	}
 	if m.languageExists == nil {
 		return true, nil
 	}
-	return m.languageExists[code], nil
+	for _, code := range codes {
+		if !m.languageExists[code] {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 type mockUserUpsertRepositoryForReg struct {
@@ -315,7 +320,7 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.Equal(t, []string{"jpn", "kor"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn", "kor"}}, repo.languageBatches)
 		assert.True(t, repo.upsertCalled)
 	})
 
@@ -335,7 +340,7 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		})
 
 		assert.ErrorIs(t, err, domain.ErrInvalidContestRegistration)
-		assert.Equal(t, []string{"invalid"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"invalid"}}, repo.languageBatches)
 		assert.False(t, repo.upsertCalled)
 	})
 
@@ -355,7 +360,7 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		})
 
 		assert.ErrorIs(t, err, domain.ErrInvalidContestRegistration)
-		assert.Equal(t, []string{"jpn", "invalid"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn", "invalid"}}, repo.languageBatches)
 		assert.False(t, repo.upsertCalled)
 	})
 
@@ -376,7 +381,7 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		})
 
 		assert.ErrorIs(t, err, lookupErr)
-		assert.Equal(t, []string{"jpn"}, repo.languageLookups)
+		assert.Equal(t, [][]string{{"jpn"}}, repo.languageBatches)
 		assert.False(t, repo.upsertCalled)
 	})
 }

--- a/services/immersion-api/domain/registrationupsert_test.go
+++ b/services/immersion-api/domain/registrationupsert_test.go
@@ -2,6 +2,7 @@ package domain_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -20,9 +21,12 @@ type mockRegistrationUpsertRepository struct {
 	upsertCalled     bool
 	upsertCalledWith *domain.RegistrationUpsertRequest
 
-	detachCalled     bool
-	detachCalledWith *domain.DetachContestLogsForLanguagesRequest
-	detachErr        error
+	detachCalled      bool
+	detachCalledWith  *domain.DetachContestLogsForLanguagesRequest
+	detachErr         error
+	languageExists    map[string]bool
+	languageExistsErr error
+	languageLookups   []string
 }
 
 func (m *mockRegistrationUpsertRepository) FindContestByID(ctx context.Context, req *domain.ContestFindRequest) (*domain.ContestView, error) {
@@ -43,6 +47,17 @@ func (m *mockRegistrationUpsertRepository) DetachContestLogsForLanguages(ctx con
 	m.detachCalled = true
 	m.detachCalledWith = req
 	return m.detachErr
+}
+
+func (m *mockRegistrationUpsertRepository) LanguageExists(_ context.Context, code string) (bool, error) {
+	m.languageLookups = append(m.languageLookups, code)
+	if m.languageExistsErr != nil {
+		return false, m.languageExistsErr
+	}
+	if m.languageExists == nil {
+		return true, nil
+	}
+	return m.languageExists[code], nil
 }
 
 type mockUserUpsertRepositoryForReg struct {
@@ -282,5 +297,86 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, repo.upsertCalled)
 		assert.Equal(t, existingRegID, repo.upsertCalledWith.ID())
+	})
+
+	t.Run("allows known language codes", func(t *testing.T) {
+		userRepo := &mockUserUpsertRepositoryForReg{}
+		userUpsert := domain.NewUserUpsert(userRepo)
+		repo := &mockRegistrationUpsertRepository{
+			contest:        validContest,
+			findRegErr:     domain.ErrNotFound,
+			languageExists: map[string]bool{"jpn": true, "kor": true},
+		}
+		svc := domain.NewRegistrationUpsert(repo, userUpsert)
+
+		err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.RegistrationUpsertRequest{
+			ContestID:     contestID,
+			LanguageCodes: []string{"jpn", "kor"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"jpn", "kor"}, repo.languageLookups)
+		assert.True(t, repo.upsertCalled)
+	})
+
+	t.Run("rejects an unknown language code for an unrestricted contest", func(t *testing.T) {
+		userRepo := &mockUserUpsertRepositoryForReg{}
+		userUpsert := domain.NewUserUpsert(userRepo)
+		repo := &mockRegistrationUpsertRepository{
+			contest:        validContest,
+			findRegErr:     domain.ErrNotFound,
+			languageExists: map[string]bool{"invalid": false},
+		}
+		svc := domain.NewRegistrationUpsert(repo, userUpsert)
+
+		err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.RegistrationUpsertRequest{
+			ContestID:     contestID,
+			LanguageCodes: []string{"invalid"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrInvalidContestRegistration)
+		assert.Equal(t, []string{"invalid"}, repo.languageLookups)
+		assert.False(t, repo.upsertCalled)
+	})
+
+	t.Run("rejects a mixed list containing an unknown language code", func(t *testing.T) {
+		userRepo := &mockUserUpsertRepositoryForReg{}
+		userUpsert := domain.NewUserUpsert(userRepo)
+		repo := &mockRegistrationUpsertRepository{
+			contest:        validContest,
+			findRegErr:     domain.ErrNotFound,
+			languageExists: map[string]bool{"jpn": true, "invalid": false},
+		}
+		svc := domain.NewRegistrationUpsert(repo, userUpsert)
+
+		err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.RegistrationUpsertRequest{
+			ContestID:     contestID,
+			LanguageCodes: []string{"jpn", "invalid"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrInvalidContestRegistration)
+		assert.Equal(t, []string{"jpn", "invalid"}, repo.languageLookups)
+		assert.False(t, repo.upsertCalled)
+	})
+
+	t.Run("returns a language lookup error without upserting a registration", func(t *testing.T) {
+		lookupErr := errors.New("language repository unavailable")
+		userRepo := &mockUserUpsertRepositoryForReg{}
+		userUpsert := domain.NewUserUpsert(userRepo)
+		repo := &mockRegistrationUpsertRepository{
+			contest:           validContest,
+			findRegErr:        domain.ErrNotFound,
+			languageExistsErr: lookupErr,
+		}
+		svc := domain.NewRegistrationUpsert(repo, userUpsert)
+
+		err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.RegistrationUpsertRequest{
+			ContestID:     contestID,
+			LanguageCodes: []string{"jpn"},
+		})
+
+		assert.ErrorIs(t, err, lookupErr)
+		assert.Equal(t, []string{"jpn"}, repo.languageLookups)
+		assert.False(t, repo.upsertCalled)
 	})
 }

--- a/services/immersion-api/storage/postgres/repository/BUILD.bazel
+++ b/services/immersion-api/storage/postgres/repository/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     srcs = [
         "logtracking_test.go",
         "repo_findscoringruleset_test.go",
+        "repo_languageexists_test.go",
     ],
     embed = [":repository"],
     deps = [

--- a/services/immersion-api/storage/postgres/repository/repo_languageexists.go
+++ b/services/immersion-api/storage/postgres/repository/repo_languageexists.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"fmt"
+
+	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres"
 )
 
 func (r *Repository) LanguageExists(ctx context.Context, code string) (bool, error) {
@@ -11,4 +13,30 @@ func (r *Repository) LanguageExists(ctx context.Context, code string) (bool, err
 		return false, fmt.Errorf("could not check if language exists: %w", err)
 	}
 	return len(languages) > 0, nil
+}
+
+func (r *Repository) LanguagesExist(ctx context.Context, codes []string) (bool, error) {
+	if len(codes) == 0 {
+		return true, nil
+	}
+
+	languages, err := r.q.GetLanguagesByCode(ctx, codes)
+	if err != nil {
+		return false, fmt.Errorf("could not check if languages exist: %w", err)
+	}
+
+	return allRequestedLanguagesExist(codes, languages), nil
+}
+
+func allRequestedLanguagesExist(codes []string, languages []postgres.Language) bool {
+	missingCodes := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		missingCodes[code] = struct{}{}
+	}
+
+	for _, language := range languages {
+		delete(missingCodes, language.Code)
+	}
+
+	return len(missingCodes) == 0
 }

--- a/services/immersion-api/storage/postgres/repository/repo_languageexists_test.go
+++ b/services/immersion-api/storage/postgres/repository/repo_languageexists_test.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres"
+)
+
+func TestAllRequestedLanguagesExist(t *testing.T) {
+	tests := []struct {
+		name      string
+		codes     []string
+		languages []postgres.Language
+		want      bool
+	}{
+		{
+			name: "empty request",
+			want: true,
+		},
+		{
+			name:  "all requested languages are present",
+			codes: []string{"jpn", "kor"},
+			languages: []postgres.Language{
+				{Code: "kor"},
+				{Code: "jpn"},
+			},
+			want: true,
+		},
+		{
+			name:  "requested language is missing",
+			codes: []string{"jpn", "kor"},
+			languages: []postgres.Language{
+				{Code: "jpn"},
+			},
+			want: false,
+		},
+		{
+			name:  "duplicate requested languages are present",
+			codes: []string{"jpn", "jpn", "kor"},
+			languages: []postgres.Language{
+				{Code: "jpn"},
+				{Code: "kor"},
+			},
+			want: true,
+		},
+		{
+			name:  "duplicate request still detects another missing language",
+			codes: []string{"jpn", "jpn", "kor"},
+			languages: []postgres.Language{
+				{Code: "jpn"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, allRequestedLanguagesExist(tt.codes, tt.languages))
+		})
+	}
+}


### PR DESCRIPTION
Closes #546.

## Summary

- validate every contest language allow-list code against the authoritative language repository before contest creation
- validate every registration language code even when the contest is unrestricted
- batch each non-empty language list into one database query, with duplicate-safe comparison
- reject unknown codes with the existing operation-specific domain errors
- preserve repository lookup errors and stop before any persistence or log-detachment mutation
- cover valid, invalid, mixed, and repository-error cases for both write paths

No database migration, SQLC generation, or OpenAPI change is required.

## Design

[Issue #546 language-list validation design](https://draft.apps.lab/documents/tadoku-issue-546-language-validation.html?version=2)

## Validation

- `bazel test //services/immersion-api/domain:domain_test --test_filter='TestContestCreate_Execute.*|TestRegistrationUpsert_Execute.*' --nocache_test_results`
- `bazel test //services/immersion-api/storage/postgres/repository:repository_test --test_filter='TestAllRequestedLanguagesExist.*' --nocache_test_results`
- `bazel build //services/...`
- `bazel test //services/...` — 19/19 test targets passed
- `bazel run //:gazelle -- -mode=diff`
- `git diff --check`
