### PR TITLE
Show not found page for deleted logs

### DIFF
--- a/frontend/apps/webv2/app/immersion/api.ts
+++ b/frontend/apps/webv2/app/immersion/api.ts
@@ -1088,7 +1088,13 @@ export const useLog = (id: string, options?: { enabled?: boolean }) =>
 
       return Log.parse(await response.json())
     },
-    options,
+    {
+      ...options,
+      retry: (failureCount, error) =>
+        error instanceof Error && error.message === '404'
+          ? false
+          : failureCount < 3,
+    },
   )
 
 const UserActivityScore = z.object({

--- a/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
@@ -27,12 +27,6 @@ vi.mock('next/router', () => ({
   useRouter: () => ({ query: { id: 'deleted-log' } }),
 }))
 
-vi.mock('next/error', () => ({
-  default: ({ statusCode }: { statusCode: number }) => (
-    <main>Not found ({statusCode})</main>
-  ),
-}))
-
 import LogPage from '../../pages/logs/[id]'
 
 describe('log details errors', () => {
@@ -50,7 +44,15 @@ describe('log details errors', () => {
       isLoading: false,
     })
 
-    expect(renderToStaticMarkup(<LogPage />)).toContain('Not found (404)')
+    const markup = renderToStaticMarkup(<LogPage />)
+
+    expect(markup).toContain('Log not found')
+    expect(markup).toContain(
+      'This log may have been deleted, or the link may be incorrect.',
+    )
+    expect(markup).toContain('href="/"')
+    expect(markup).toContain('class="btn primary"')
+    expect(markup).not.toContain('next-error-h1')
   })
 
   it('keeps the transient error message for other failures', () => {
@@ -75,6 +77,6 @@ describe('log details errors', () => {
       isLoading: false,
     })
 
-    expect(renderToStaticMarkup(<LogPage />)).toContain('Not found (404)')
+    expect(renderToStaticMarkup(<LogPage />)).toContain('Log not found')
   })
 })

--- a/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+Reflect.set(globalThis, 'React', React)
+
+const { useLog } = vi.hoisted(() => ({ useLog: vi.fn() }))
+
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: {} }),
+}))
+
+vi.mock('@app/immersion/api', () => ({
+  useDeleteLog: vi.fn(),
+  useLog,
+}))
+
+vi.mock('@app/common/session', () => ({
+  useSession: () => [undefined],
+  useUserRole: () => 'user',
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: 'deleted-log' } }),
+}))
+
+vi.mock('next/error', () => ({
+  default: ({ statusCode }: { statusCode: number }) => (
+    <main>Not found ({statusCode})</main>
+  ),
+}))
+
+import LogPage from '../../pages/logs/[id]'
+
+describe('log details errors', () => {
+  beforeEach(() => {
+    useLog.mockReset()
+  })
+
+  it('renders the not found page when the log API returns 404', () => {
+    useLog.mockReturnValue({
+      error: new Error('404'),
+      isError: true,
+      isIdle: false,
+      isLoading: false,
+    })
+
+    expect(renderToStaticMarkup(<LogPage />)).toContain('Not found (404)')
+  })
+
+  it('keeps the transient error message for other failures', () => {
+    useLog.mockReturnValue({
+      error: new Error('500'),
+      isError: true,
+      isIdle: false,
+      isLoading: false,
+    })
+
+    expect(renderToStaticMarkup(<LogPage />)).toContain(
+      'Could not load page, please try again later.',
+    )
+  })
+})

--- a/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 Reflect.set(globalThis, 'React', React)
 
-const { useLog } = vi.hoisted(() => ({ useLog: vi.fn() }))
+const { useLog, useUserRole } = vi.hoisted(() => ({
+  useLog: vi.fn(),
+  useUserRole: vi.fn(),
+}))
 
 vi.mock('next/config', () => ({
   default: () => ({ publicRuntimeConfig: {} }),
@@ -17,7 +20,7 @@ vi.mock('@app/immersion/api', () => ({
 
 vi.mock('@app/common/session', () => ({
   useSession: () => [undefined],
-  useUserRole: () => 'user',
+  useUserRole,
 }))
 
 vi.mock('next/router', () => ({
@@ -35,6 +38,8 @@ import LogPage from '../../pages/logs/[id]'
 describe('log details errors', () => {
   beforeEach(() => {
     useLog.mockReset()
+    useUserRole.mockReset()
+    useUserRole.mockReturnValue('user')
   })
 
   it('renders the not found page when the log API returns 404', () => {
@@ -59,5 +64,17 @@ describe('log details errors', () => {
     expect(renderToStaticMarkup(<LogPage />)).toContain(
       'Could not load page, please try again later.',
     )
+  })
+
+  it('renders the not found page for a guest without a resolved role', () => {
+    useUserRole.mockReturnValue(undefined)
+    useLog.mockReturnValue({
+      error: new Error('404'),
+      isError: true,
+      isIdle: false,
+      isLoading: false,
+    })
+
+    expect(renderToStaticMarkup(<LogPage />)).toContain('Not found (404)')
   })
 })

--- a/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-not-found-page.test.tsx
@@ -50,8 +50,12 @@ describe('log details errors', () => {
     expect(markup).toContain(
       'This log may have been deleted, or the link may be incorrect.',
     )
+    expect(markup).toContain('<p class="mt-2">')
+    expect(markup).not.toContain('<p class="subtitle')
+    expect(markup).not.toContain('class="card"')
     expect(markup).toContain('href="/"')
-    expect(markup).toContain('class="btn primary"')
+    expect(markup).toContain('class="btn"')
+    expect(markup).not.toContain('class="btn primary"')
     expect(markup).not.toContain('next-error-h1')
   })
 

--- a/frontend/apps/webv2/app/immersion/log-query.test.ts
+++ b/frontend/apps/webv2/app/immersion/log-query.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { useQuery } = vi.hoisted(() => ({ useQuery: vi.fn() }))
+
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: { apiEndpoint: '' } }),
+}))
+
+vi.mock('react-query', () => ({
+  useMutation: vi.fn(),
+  useQuery,
+  useQueryClient: vi.fn(),
+}))
+
+import { useLog } from './api'
+
+describe('useLog', () => {
+  beforeEach(() => {
+    useQuery.mockClear()
+  })
+
+  it('does not retry a not found response', () => {
+    useLog('deleted-log')
+
+    const options = useQuery.mock.calls[0]?.[2]
+    expect(options).toMatchObject({ retry: expect.any(Function) })
+    expect(options.retry(0, new Error('404'))).toBe(false)
+  })
+
+  it('keeps the default retry limit for other errors', () => {
+    useLog('temporarily-unavailable-log')
+
+    const options = useQuery.mock.calls[0]?.[2]
+    expect(options.retry(0, new Error('500'))).toBe(true)
+    expect(options.retry(2, new Error('500'))).toBe(true)
+    expect(options.retry(3, new Error('500'))).toBe(false)
+  })
+})

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -14,6 +14,7 @@ import { LogDetailsV2 } from '@app/immersion/LogDetailsV2'
 import { HomeIcon, TrashIcon } from '@heroicons/react/20/solid'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { DateTime } from 'luxon'
+import ErrorPage from 'next/error'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -32,6 +33,10 @@ const Page = () => {
   }
 
   if (log.isError) {
+    if (log.error instanceof Error && log.error.message === '404') {
+      return <ErrorPage statusCode={404} />
+    }
+
     return (
       <span className="flash error">
         Could not load page, please try again later.

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -14,7 +14,6 @@ import { LogDetailsV2 } from '@app/immersion/LogDetailsV2'
 import { HomeIcon, TrashIcon } from '@heroicons/react/20/solid'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { DateTime } from 'luxon'
-import ErrorPage from 'next/error'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -34,7 +33,26 @@ const Page = () => {
 
   if (log.isError) {
     if (log.error instanceof Error && log.error.message === '404') {
-      return <ErrorPage statusCode={404} />
+      return (
+        <>
+          <Head>
+            <title>Log not found - Tadoku</title>
+          </Head>
+          <div className="max-w-2xl">
+            <div className="card">
+              <h1 className="title">Log not found</h1>
+              <p className="subtitle mt-2">
+                This log may have been deleted, or the link may be incorrect.
+              </p>
+              <div className="mt-4">
+                <Link href={routes.home()} className="btn primary">
+                  Back to home
+                </Link>
+              </div>
+            </div>
+          </div>
+        </>
+      )
     }
 
     return (

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -28,7 +28,7 @@ const Page = () => {
   const log = useLog(id)
   const role = useUserRole()
 
-  if (log.isLoading || log.isIdle || role === undefined) {
+  if (log.isLoading || log.isIdle) {
     return <Loading />
   }
 
@@ -42,6 +42,10 @@ const Page = () => {
         Could not load page, please try again later.
       </span>
     )
+  }
+
+  if (role === undefined) {
+    return <Loading />
   }
 
   if (role === 'admin') {

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -39,16 +39,14 @@ const Page = () => {
             <title>Log not found - Tadoku</title>
           </Head>
           <div className="max-w-2xl">
-            <div className="card">
-              <h1 className="title">Log not found</h1>
-              <p className="subtitle mt-2">
-                This log may have been deleted, or the link may be incorrect.
-              </p>
-              <div className="mt-4">
-                <Link href={routes.home()} className="btn primary">
-                  Back to home
-                </Link>
-              </div>
+            <h1 className="title">Log not found</h1>
+            <p className="mt-2">
+              This log may have been deleted, or the link may be incorrect.
+            </p>
+            <div className="mt-4">
+              <Link href={routes.home()} className="btn">
+                Back to home
+              </Link>
             </div>
           </div>
         </>

--- a/services/immersion-api/domain/logfind.go
+++ b/services/immersion-api/domain/logfind.go
@@ -25,18 +25,20 @@ func NewLogFind(repo LogFindRepository) *LogFind {
 }
 
 func (s *LogFind) Execute(ctx context.Context, req *LogFindRequest) (*Log, error) {
-	// Check authorization before making DB call
 	session := commondomain.ParseUserIdentity(ctx)
-	if session == nil {
-		return nil, ErrUnauthorized
+	userID := uuid.Nil
+	admin := false
+	authenticated := session != nil && session.Subject != "guest"
+	if authenticated {
+		var err error
+		userID, err = uuid.Parse(session.Subject)
+		if err != nil {
+			return nil, ErrUnauthorized
+		}
+		admin = isAdmin(ctx)
 	}
 
-	userID, err := uuid.Parse(session.Subject)
-	if err != nil {
-		return nil, ErrUnauthorized
-	}
-
-	req.IncludeDeleted = isAdmin(ctx)
+	req.IncludeDeleted = admin
 
 	log, err := s.repo.FindLogByID(ctx, req)
 	if err != nil {
@@ -48,9 +50,8 @@ func (s *LogFind) Execute(ctx context.Context, req *LogFindRequest) (*Log, error
 	}
 
 	// Needed to prevent leaking private registrations, only show to admins and the owner of the log
-	isAdmin := isAdmin(ctx)
-	isOwner := log.UserID == userID
-	if !isAdmin && !isOwner {
+	isOwner := authenticated && log.UserID == userID
+	if !admin && !isOwner {
 		log.Registrations = nil
 	}
 

--- a/services/immersion-api/domain/logfind_test.go
+++ b/services/immersion-api/domain/logfind_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tadoku/tadoku/services/immersion-api/domain"
 )
 
@@ -137,24 +138,43 @@ func TestLogFind_Execute(t *testing.T) {
 	}
 }
 
-func TestLogFind_NoSession(t *testing.T) {
+func TestLogFind_GuestReturnsNotFoundForDeletedLog(t *testing.T) {
 	logID := uuid.New()
-	ownerUserID := uuid.New()
 
 	repo := &logFindRepositoryMock{
+		err: domain.ErrNotFound,
+	}
+	service := domain.NewLogFind(repo)
+
+	ctx := ctxWithGuest()
+
+	result, err := service.Execute(ctx, &domain.LogFindRequest{ID: logID})
+
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+	assert.Nil(t, result)
+	require.NotNil(t, repo.capturedRequest)
+	assert.False(t, repo.capturedRequest.IncludeDeleted)
+}
+
+func TestLogFind_GuestCanFindActiveLogWithoutRegistrations(t *testing.T) {
+	repo := &logFindRepositoryMock{
 		log: &domain.Log{
-			ID:     logID,
-			UserID: ownerUserID,
+			ID:         uuid.New(),
+			UserID:     uuid.New(),
+			ActivityID: 1,
+			Registrations: []domain.ContestRegistrationReference{
+				{RegistrationID: uuid.New()},
+			},
 		},
 	}
 	service := domain.NewLogFind(repo)
 
-	ctx := context.Background() // No session
+	result, err := service.Execute(ctxWithGuest(), &domain.LogFindRequest{ID: repo.log.ID})
 
-	result, err := service.Execute(ctx, &domain.LogFindRequest{ID: logID})
-
-	assert.ErrorIs(t, err, domain.ErrUnauthorized)
-	assert.Nil(t, result)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, repo.capturedRequest.IncludeDeleted)
+	assert.Nil(t, result.Registrations)
 }
 
 func copyLog(l *domain.Log) *domain.Log {


### PR DESCRIPTION
## Summary

- return 404 for deleted or missing logs requested by guests instead of treating the request as unauthorized
- keep active log details public while redacting registrations from guests and non-owners
- allow admins to retrieve deleted logs
- render a minimal Tadoku-styled not-found page when the log API reports a missing log, including before guest role resolution
- stop React Query retries for 404 responses while retaining retries for transient errors

Fixes #594

## Verification

- `bazel build //services/...`
- `bazel test //services/...`
- `pnpm --filter webv2 exec vitest run app/immersion/log-query.test.ts app/immersion/log-not-found-page.test.tsx`
- `pnpm --filter webv2 exec tsc --noEmit`
- `pnpm --filter webv2 lint`
- `pnpm build`
- live guest request at `https://tadoku.dev.lab`: the API returns 404 and the page renders `Log not found` with a plain heading, normal body copy, and neutral home button
- live retry check: one missing-log API request on navigation and still one request after three seconds

## Development note

The observed blank/reload loop came from production `.next` artifacts being live-synced into the running Next development container. Tilt was paused for the production build, the generated cache was moved out of the sync path, and the cleanly restarted environment no longer loops.