### PR TITLE
Fix stale official leaderboards

### DIFF
--- a/services/immersion-api/domain/leaderboardoutboxworker.go
+++ b/services/immersion-api/domain/leaderboardoutboxworker.go
@@ -31,8 +31,9 @@ type LeaderboardOutboxWorkerRepository interface {
 // LeaderboardOutboxUpdater is the narrow interface the outbox worker
 // needs from LeaderboardUpdater.
 type LeaderboardOutboxUpdater interface {
-	UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID)
-	UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID)
+	UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID) error
+	UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID) error
+	RebuildOfficialLeaderboards(ctx context.Context, year int) error
 }
 
 // LeaderboardOutboxWorker polls the leaderboard_outbox table and processes events
@@ -62,6 +63,10 @@ func NewLeaderboardOutboxWorker(
 // Run polls the outbox table at the configured interval until the context
 // is cancelled. It also periodically cleans up old processed events.
 func (w *LeaderboardOutboxWorker) Run(ctx context.Context) {
+	if err := w.updater.RebuildOfficialLeaderboards(ctx, w.clock.Now().Year()); err != nil {
+		slog.ErrorContext(ctx, "outbox worker: startup leaderboard reconciliation failed", "error", err)
+	}
+
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 
@@ -94,61 +99,84 @@ func (w *LeaderboardOutboxWorker) processBatch(ctx context.Context) {
 
 		// Deduplicate: only process one event per unique (event_type, user_id, contest_id/year)
 		type dedupeKey struct {
-			eventType string
-			userID    uuid.UUID
-			contestID uuid.UUID // zero for official scores
-			year      int       // zero for contest scores
+			eventType    string
+			userID       uuid.UUID
+			contestID    uuid.UUID // zero for official scores
+			hasContestID bool
+			year         int // zero for contest scores
+			hasYear      bool
 		}
-		seen := map[dedupeKey]struct{}{}
-		var allIDs []int64
+		type eventGroup struct {
+			representative LeaderboardOutboxEvent
+			ids            []int64
+		}
+		groups := make(map[dedupeKey]*eventGroup)
+		groupOrder := make([]dedupeKey, 0, len(events))
 
 		for _, event := range events {
-			allIDs = append(allIDs, event.ID)
-
 			key := dedupeKey{
 				eventType: event.EventType,
 				userID:    event.UserID,
 			}
 			if event.ContestID != nil {
 				key.contestID = *event.ContestID
+				key.hasContestID = true
 			}
 			if event.Year != nil {
 				key.year = *event.Year
+				key.hasYear = true
 			}
 
-			if _, exists := seen[key]; exists {
-				continue
+			group, exists := groups[key]
+			if !exists {
+				group = &eventGroup{representative: event}
+				groups[key] = group
+				groupOrder = append(groupOrder, key)
 			}
-			seen[key] = struct{}{}
-
-			w.processEvent(ctx, event)
+			group.ids = append(group.ids, event.ID)
 		}
 
-		return allIDs
+		var processedIDs []int64
+		for _, key := range groupOrder {
+			group := groups[key]
+			if err := w.processEvent(ctx, group.representative); err != nil {
+				slog.ErrorContext(ctx, "outbox worker: event processing failed", "event_id", group.representative.ID, "error", err)
+				continue
+			}
+			processedIDs = append(processedIDs, group.ids...)
+		}
+
+		return processedIDs
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "outbox worker: batch processing failed", "error", err)
 	}
 }
 
-func (w *LeaderboardOutboxWorker) processEvent(ctx context.Context, event LeaderboardOutboxEvent) {
+func (w *LeaderboardOutboxWorker) processEvent(ctx context.Context, event LeaderboardOutboxEvent) error {
 	switch event.EventType {
 	case "refresh_contest_score":
 		if event.ContestID == nil {
+			// Retrying a structurally invalid event cannot make it valid. Log and
+			// acknowledge it so it cannot permanently occupy the head of the queue.
 			slog.ErrorContext(ctx, "outbox worker: refresh_contest_score event missing contest_id", "event_id", event.ID)
-			return
+			return nil
 		}
-		w.updater.UpdateUserContestScore(ctx, *event.ContestID, event.UserID)
+		return w.updater.UpdateUserContestScore(ctx, *event.ContestID, event.UserID)
 
 	case "refresh_official_scores":
 		if event.Year == nil {
+			// As above, the missing required field is not retryable.
 			slog.ErrorContext(ctx, "outbox worker: refresh_official_scores event missing year", "event_id", event.ID)
-			return
+			return nil
 		}
-		w.updater.UpdateUserOfficialScores(ctx, *event.Year, event.UserID)
+		return w.updater.UpdateUserOfficialScores(ctx, *event.Year, event.UserID)
 
 	default:
+		// Unknown event types are also permanent payload errors rather than
+		// transient update failures, so acknowledge them after logging.
 		slog.ErrorContext(ctx, fmt.Sprintf("outbox worker: unknown event type: %s", event.EventType), "event_id", event.ID)
+		return nil
 	}
 }
 

--- a/services/immersion-api/domain/leaderboardoutboxworker_test.go
+++ b/services/immersion-api/domain/leaderboardoutboxworker_test.go
@@ -36,8 +36,13 @@ func (m *mockLeaderboardOutboxRepository) CleanupProcessedOutboxEvents(ctx conte
 }
 
 type mockLeaderboardOutboxUpdater struct {
-	contestCalls  []mockLeaderboardOutboxContestCall
-	officialCalls []mockLeaderboardOutboxOfficialCall
+	contestCalls         []mockLeaderboardOutboxContestCall
+	officialCalls        []mockLeaderboardOutboxOfficialCall
+	rebuildOfficialCalls []int
+	contestErr           error
+	officialErr          error
+	rebuildOfficialErr   error
+	rebuildCalled        chan int
 }
 
 type mockLeaderboardOutboxContestCall struct {
@@ -50,18 +55,29 @@ type mockLeaderboardOutboxOfficialCall struct {
 	UserID uuid.UUID
 }
 
-func (m *mockLeaderboardOutboxUpdater) UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID) {
+func (m *mockLeaderboardOutboxUpdater) UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID) error {
 	m.contestCalls = append(m.contestCalls, mockLeaderboardOutboxContestCall{ContestID: contestID, UserID: userID})
+	return m.contestErr
 }
 
-func (m *mockLeaderboardOutboxUpdater) UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID) {
+func (m *mockLeaderboardOutboxUpdater) UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID) error {
 	m.officialCalls = append(m.officialCalls, mockLeaderboardOutboxOfficialCall{Year: year, UserID: userID})
+	return m.officialErr
+}
+
+func (m *mockLeaderboardOutboxUpdater) RebuildOfficialLeaderboards(ctx context.Context, year int) error {
+	m.rebuildOfficialCalls = append(m.rebuildOfficialCalls, year)
+	if m.rebuildCalled != nil {
+		m.rebuildCalled <- year
+	}
+	return m.rebuildOfficialErr
 }
 
 func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 	userID := uuid.New()
 	contestID := uuid.New()
 	year2026 := 2026
+	now := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
 
 	t.Run("processes refresh_contest_score events", func(t *testing.T) {
 		updater := &mockLeaderboardOutboxUpdater{}
@@ -76,7 +92,7 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			},
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		worker.ProcessBatchForTest(context.Background())
 
 		require.Len(t, updater.contestCalls, 1)
@@ -99,13 +115,73 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			},
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		worker.ProcessBatchForTest(context.Background())
 
 		assert.Empty(t, updater.contestCalls)
 		require.Len(t, updater.officialCalls, 1)
 		assert.Equal(t, 2026, updater.officialCalls[0].Year)
 		assert.Equal(t, userID, updater.officialCalls[0].UserID)
+		assert.Equal(t, []int64{2}, repo.markedIDs)
+	})
+
+	t.Run("keeps refresh_official_scores events pending when the cache update fails", func(t *testing.T) {
+		updater := &mockLeaderboardOutboxUpdater{officialErr: errors.New("valkey unavailable")}
+		repo := &mockLeaderboardOutboxRepository{
+			events: []domain.LeaderboardOutboxEvent{
+				{
+					ID:        2,
+					EventType: "refresh_official_scores",
+					UserID:    userID,
+					Year:      &year2026,
+				},
+			},
+		}
+
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
+		worker.ProcessBatchForTest(context.Background())
+
+		require.Len(t, updater.officialCalls, 1)
+		assert.Empty(t, repo.markedIDs)
+	})
+
+	t.Run("marks all duplicate events only after their update succeeds", func(t *testing.T) {
+		updater := &mockLeaderboardOutboxUpdater{officialErr: errors.New("valkey unavailable")}
+		repo := &mockLeaderboardOutboxRepository{
+			events: []domain.LeaderboardOutboxEvent{
+				{ID: 1, EventType: "refresh_official_scores", UserID: userID, Year: &year2026},
+				{ID: 2, EventType: "refresh_official_scores", UserID: userID, Year: &year2026},
+				{ID: 3, EventType: "refresh_official_scores", UserID: userID, Year: &year2026},
+			},
+		}
+
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
+		worker.ProcessBatchForTest(context.Background())
+
+		require.Len(t, updater.officialCalls, 1)
+		assert.Empty(t, repo.markedIDs)
+
+		updater.officialErr = nil
+		worker.ProcessBatchForTest(context.Background())
+
+		require.Len(t, updater.officialCalls, 2)
+		assert.Equal(t, []int64{1, 2, 3}, repo.markedIDs)
+	})
+
+	t.Run("marks successful groups while leaving failed groups pending", func(t *testing.T) {
+		updater := &mockLeaderboardOutboxUpdater{officialErr: errors.New("valkey unavailable")}
+		repo := &mockLeaderboardOutboxRepository{
+			events: []domain.LeaderboardOutboxEvent{
+				{ID: 1, EventType: "refresh_official_scores", UserID: userID, Year: &year2026},
+				{ID: 2, EventType: "refresh_contest_score", UserID: userID, ContestID: &contestID},
+			},
+		}
+
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
+		worker.ProcessBatchForTest(context.Background())
+
+		require.Len(t, updater.officialCalls, 1)
+		require.Len(t, updater.contestCalls, 1)
 		assert.Equal(t, []int64{2}, repo.markedIDs)
 	})
 
@@ -134,7 +210,7 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			},
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		worker.ProcessBatchForTest(context.Background())
 
 		// Only one actual update should happen despite 3 events
@@ -171,7 +247,7 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			},
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		worker.ProcessBatchForTest(context.Background())
 
 		require.Len(t, updater.contestCalls, 2)
@@ -185,7 +261,7 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			events: []domain.LeaderboardOutboxEvent{},
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		worker.ProcessBatchForTest(context.Background())
 
 		assert.Empty(t, updater.contestCalls)
@@ -199,11 +275,49 @@ func TestLeaderboardOutboxWorker_ProcessEvent(t *testing.T) {
 			batchErr: errors.New("db connection lost"),
 		}
 
-		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: time.Now()}, time.Second)
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
 		// Should not panic
 		worker.ProcessBatchForTest(context.Background())
 
 		assert.Empty(t, updater.contestCalls)
 		assert.Empty(t, updater.officialCalls)
 	})
+
+	t.Run("marks permanently malformed events so they do not poison the queue", func(t *testing.T) {
+		updater := &mockLeaderboardOutboxUpdater{}
+		repo := &mockLeaderboardOutboxRepository{
+			events: []domain.LeaderboardOutboxEvent{
+				{ID: 1, EventType: "refresh_contest_score", UserID: userID},
+				{ID: 2, EventType: "refresh_official_scores", UserID: userID},
+				{ID: 3, EventType: "not_a_real_event", UserID: userID},
+			},
+		}
+
+		worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Second)
+		worker.ProcessBatchForTest(context.Background())
+
+		assert.Empty(t, updater.contestCalls)
+		assert.Empty(t, updater.officialCalls)
+		assert.Equal(t, []int64{1, 2, 3}, repo.markedIDs)
+	})
+}
+
+func TestLeaderboardOutboxWorker_RunReconcilesOfficialLeaderboardsAtStartup(t *testing.T) {
+	now := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	rebuildCalled := make(chan int, 1)
+	updater := &mockLeaderboardOutboxUpdater{rebuildCalled: rebuildCalled}
+	repo := &mockLeaderboardOutboxRepository{}
+	worker := domain.NewLeaderboardOutboxWorker(repo, updater, &mockClock{now: now}, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+
+	assert.Equal(t, 2026, <-rebuildCalled)
+	cancel()
+	<-done
+	assert.Equal(t, []int{2026}, updater.rebuildOfficialCalls)
 }

--- a/services/immersion-api/domain/leaderboardupdater.go
+++ b/services/immersion-api/domain/leaderboardupdater.go
@@ -2,7 +2,7 @@ package domain
 
 import (
 	"context"
-	"log/slog"
+	"fmt"
 
 	"github.com/google/uuid"
 )
@@ -77,84 +77,82 @@ func NewLeaderboardUpdater(store LeaderboardStore, repo LeaderboardRepository) *
 // UpdateUserContestScore recalculates a user's total score for a contest
 // from the database and updates it in the store. If the leaderboard doesn't
 // exist in the store yet, a full rebuild is performed.
-func (u *LeaderboardUpdater) UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID) {
+func (u *LeaderboardUpdater) UpdateUserContestScore(ctx context.Context, contestID uuid.UUID, userID uuid.UUID) error {
 	score, err := u.repo.FetchUserContestScore(ctx, contestID, userID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch user contest score", "contest_id", contestID, "user_id", userID, "error", err)
-		return
+		return fmt.Errorf("fetch user contest score: %w", err)
 	}
 
 	updated, err := u.store.UpdateContestScore(ctx, contestID, userID, score)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to update user contest score", "contest_id", contestID, "user_id", userID, "error", err)
-		return
+		return fmt.Errorf("update user contest score: %w", err)
 	}
 	if updated {
-		return
+		return nil
 	}
 
 	// Leaderboard doesn't exist in store yet, do a full rebuild
-	u.RebuildContestLeaderboard(ctx, contestID)
+	return u.RebuildContestLeaderboard(ctx, contestID)
 }
 
 // UpdateUserOfficialScores recalculates a user's yearly and global scores
 // from the database and updates them in the store atomically. If either
 // leaderboard doesn't exist, a full rebuild of that leaderboard is performed.
-func (u *LeaderboardUpdater) UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID) {
+func (u *LeaderboardUpdater) UpdateUserOfficialScores(ctx context.Context, year int, userID uuid.UUID) error {
 	yearlyScore, err := u.repo.FetchUserYearlyScore(ctx, year, userID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch user yearly score", "year", year, "user_id", userID, "error", err)
-		return
+		return fmt.Errorf("fetch user yearly score: %w", err)
 	}
 
 	globalScore, err := u.repo.FetchUserGlobalScore(ctx, userID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch user global score", "user_id", userID, "error", err)
-		return
+		return fmt.Errorf("fetch user global score: %w", err)
 	}
 
 	yearlyUpdated, globalUpdated, err := u.store.UpdateOfficialScores(ctx, year, userID, yearlyScore, globalScore)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to update user official scores", "year", year, "user_id", userID, "error", err)
-		return
+		return fmt.Errorf("update user official scores: %w", err)
 	}
 
 	// If either leaderboard didn't exist, rebuild both together
 	if !yearlyUpdated || !globalUpdated {
-		u.RebuildOfficialLeaderboards(ctx, year)
+		return u.RebuildOfficialLeaderboards(ctx, year)
 	}
+
+	return nil
 }
 
 // RebuildContestLeaderboard fetches all scores from the database and
 // fully rebuilds the contest leaderboard in the store.
-func (u *LeaderboardUpdater) RebuildContestLeaderboard(ctx context.Context, contestID uuid.UUID) {
+func (u *LeaderboardUpdater) RebuildContestLeaderboard(ctx context.Context, contestID uuid.UUID) error {
 	scores, err := u.repo.FetchAllContestLeaderboardScores(ctx, contestID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch contest leaderboard scores for rebuild", "contest_id", contestID, "error", err)
-		return
+		return fmt.Errorf("fetch contest leaderboard scores for rebuild: %w", err)
 	}
 
 	if err := u.store.RebuildContestLeaderboard(ctx, contestID, scores); err != nil {
-		slog.ErrorContext(ctx, "failed to rebuild contest leaderboard", "contest_id", contestID, "error", err)
+		return fmt.Errorf("rebuild contest leaderboard: %w", err)
 	}
+
+	return nil
 }
 
 // RebuildOfficialLeaderboards fetches all scores from the database and
 // atomically rebuilds both yearly and global leaderboards in the store.
-func (u *LeaderboardUpdater) RebuildOfficialLeaderboards(ctx context.Context, year int) {
+func (u *LeaderboardUpdater) RebuildOfficialLeaderboards(ctx context.Context, year int) error {
 	yearlyScores, err := u.repo.FetchAllYearlyLeaderboardScores(ctx, year)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch yearly leaderboard scores for rebuild", "year", year, "error", err)
-		return
+		return fmt.Errorf("fetch yearly leaderboard scores for rebuild: %w", err)
 	}
 
 	globalScores, err := u.repo.FetchAllGlobalLeaderboardScores(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to fetch global leaderboard scores for rebuild", "error", err)
-		return
+		return fmt.Errorf("fetch global leaderboard scores for rebuild: %w", err)
 	}
 
 	if err := u.store.RebuildOfficialLeaderboards(ctx, year, yearlyScores, globalScores); err != nil {
-		slog.ErrorContext(ctx, "failed to rebuild official leaderboards", "year", year, "error", err)
+		return fmt.Errorf("rebuild official leaderboards: %w", err)
 	}
+
+	return nil
 }

--- a/services/immersion-api/domain/leaderboardupdater_test.go
+++ b/services/immersion-api/domain/leaderboardupdater_test.go
@@ -130,8 +130,9 @@ func TestLeaderboardUpdater_UpdateUserContestScore(t *testing.T) {
 		repo := &mockLeaderboardRepo{userContestScore: 142.5}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserContestScore(ctx, contestID, userID)
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
 
+		require.NoError(t, err)
 		require.Len(t, store.updateContestCalls, 1)
 		assert.Equal(t, contestID, store.updateContestCalls[0].ContestID)
 		assert.Equal(t, userID, store.updateContestCalls[0].UserID)
@@ -148,46 +149,65 @@ func TestLeaderboardUpdater_UpdateUserContestScore(t *testing.T) {
 		repo := &mockLeaderboardRepo{userContestScore: 42.5, contestScores: dbScores}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserContestScore(ctx, contestID, userID)
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
 
+		require.NoError(t, err)
 		require.Len(t, store.rebuildContestCalls, 1)
 		assert.Equal(t, contestID, store.rebuildContestCalls[0].ContestID)
 		assert.Equal(t, dbScores, store.rebuildContestCalls[0].Scores)
 	})
 
-	t.Run("does not panic on fetch user score error", func(t *testing.T) {
+	t.Run("returns fetch user score error", func(t *testing.T) {
+		fetchErr := errors.New("database error")
 		store := &mockLeaderboardStore{}
-		repo := &mockLeaderboardRepo{userContestErr: errors.New("database error")}
+		repo := &mockLeaderboardRepo{userContestErr: fetchErr}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserContestScore(ctx, contestID, userID)
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
 
+		assert.ErrorIs(t, err, fetchErr)
 		assert.Empty(t, store.updateContestCalls)
 		assert.Empty(t, store.rebuildContestCalls)
 	})
 
-	t.Run("does not panic on store update error", func(t *testing.T) {
-		store := &mockLeaderboardStore{updateContestErr: errors.New("redis error")}
+	t.Run("returns store update error", func(t *testing.T) {
+		updateErr := errors.New("redis error")
+		store := &mockLeaderboardStore{updateContestErr: updateErr}
 		repo := &mockLeaderboardRepo{userContestScore: 50}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserContestScore(ctx, contestID, userID)
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
 
+		assert.ErrorIs(t, err, updateErr)
 		require.Len(t, store.updateContestCalls, 1)
 		assert.Empty(t, store.rebuildContestCalls)
 	})
 
-	t.Run("does not panic on rebuild error", func(t *testing.T) {
+	t.Run("returns rebuild fetch error", func(t *testing.T) {
+		fetchErr := errors.New("database timeout")
 		store := &mockLeaderboardStore{updateContestExists: false}
 		repo := &mockLeaderboardRepo{
 			userContestScore: 50,
-			contestErr:       errors.New("database timeout"),
+			contestErr:       fetchErr,
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserContestScore(ctx, contestID, userID)
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
 
+		assert.ErrorIs(t, err, fetchErr)
 		assert.Empty(t, store.rebuildContestCalls)
+	})
+
+	t.Run("returns rebuild store error", func(t *testing.T) {
+		rebuildErr := errors.New("redis error")
+		store := &mockLeaderboardStore{updateContestExists: false, rebuildContestErr: rebuildErr}
+		repo := &mockLeaderboardRepo{userContestScore: 50}
+		updater := domain.NewLeaderboardUpdater(store, repo)
+
+		err := updater.UpdateUserContestScore(ctx, contestID, userID)
+
+		assert.ErrorIs(t, err, rebuildErr)
+		require.Len(t, store.rebuildContestCalls, 1)
 	})
 }
 
@@ -207,8 +227,9 @@ func TestLeaderboardUpdater_UpdateUserOfficialScores(t *testing.T) {
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		require.NoError(t, err)
 		require.Len(t, store.updateOfficialCalls, 1)
 		assert.Equal(t, year, store.updateOfficialCalls[0].Year)
 		assert.Equal(t, userID, store.updateOfficialCalls[0].UserID)
@@ -232,8 +253,9 @@ func TestLeaderboardUpdater_UpdateUserOfficialScores(t *testing.T) {
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		require.NoError(t, err)
 		require.Len(t, store.rebuildOfficialCalls, 1)
 		assert.Equal(t, year, store.rebuildOfficialCalls[0].Year)
 		assert.Equal(t, yearlyScores, store.rebuildOfficialCalls[0].YearlyScores)
@@ -255,45 +277,100 @@ func TestLeaderboardUpdater_UpdateUserOfficialScores(t *testing.T) {
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		require.NoError(t, err)
 		require.Len(t, store.rebuildOfficialCalls, 1)
 	})
 
-	t.Run("does not panic on fetch yearly score error", func(t *testing.T) {
+	t.Run("returns fetch yearly score error", func(t *testing.T) {
+		fetchErr := errors.New("database error")
 		store := &mockLeaderboardStore{}
-		repo := &mockLeaderboardRepo{userYearlyErr: errors.New("database error")}
+		repo := &mockLeaderboardRepo{userYearlyErr: fetchErr}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		assert.ErrorIs(t, err, fetchErr)
 		assert.Empty(t, store.updateOfficialCalls)
 	})
 
-	t.Run("does not panic on fetch global score error", func(t *testing.T) {
+	t.Run("returns fetch global score error", func(t *testing.T) {
+		fetchErr := errors.New("database error")
 		store := &mockLeaderboardStore{}
 		repo := &mockLeaderboardRepo{
 			userYearlyScore: 200,
-			userGlobalErr:   errors.New("database error"),
+			userGlobalErr:   fetchErr,
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		assert.ErrorIs(t, err, fetchErr)
 		assert.Empty(t, store.updateOfficialCalls)
 	})
 
-	t.Run("does not panic on store update error", func(t *testing.T) {
-		store := &mockLeaderboardStore{updateOfficialErr: errors.New("redis error")}
+	t.Run("returns store update error", func(t *testing.T) {
+		updateErr := errors.New("redis error")
+		store := &mockLeaderboardStore{updateOfficialErr: updateErr}
 		repo := &mockLeaderboardRepo{
 			userYearlyScore: 200,
 			userGlobalScore: 500,
 		}
 		updater := domain.NewLeaderboardUpdater(store, repo)
 
-		updater.UpdateUserOfficialScores(ctx, year, userID)
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
 
+		assert.ErrorIs(t, err, updateErr)
 		require.Len(t, store.updateOfficialCalls, 1)
 		assert.Empty(t, store.rebuildOfficialCalls)
+	})
+
+	t.Run("returns rebuild yearly fetch error", func(t *testing.T) {
+		fetchErr := errors.New("database error")
+		store := &mockLeaderboardStore{updateOfficialYearly: false, updateOfficialGlobal: true}
+		repo := &mockLeaderboardRepo{
+			userYearlyScore: 200,
+			userGlobalScore: 500,
+			yearlyErr:       fetchErr,
+		}
+		updater := domain.NewLeaderboardUpdater(store, repo)
+
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
+
+		assert.ErrorIs(t, err, fetchErr)
+		assert.Empty(t, store.rebuildOfficialCalls)
+	})
+
+	t.Run("returns rebuild global fetch error", func(t *testing.T) {
+		fetchErr := errors.New("database error")
+		store := &mockLeaderboardStore{updateOfficialYearly: true, updateOfficialGlobal: false}
+		repo := &mockLeaderboardRepo{
+			userYearlyScore: 200,
+			userGlobalScore: 500,
+			globalErr:       fetchErr,
+		}
+		updater := domain.NewLeaderboardUpdater(store, repo)
+
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
+
+		assert.ErrorIs(t, err, fetchErr)
+		assert.Empty(t, store.rebuildOfficialCalls)
+	})
+
+	t.Run("returns rebuild store error", func(t *testing.T) {
+		rebuildErr := errors.New("redis error")
+		store := &mockLeaderboardStore{
+			updateOfficialYearly: false,
+			updateOfficialGlobal: true,
+			rebuildOfficialErr:   rebuildErr,
+		}
+		repo := &mockLeaderboardRepo{userYearlyScore: 200, userGlobalScore: 500}
+		updater := domain.NewLeaderboardUpdater(store, repo)
+
+		err := updater.UpdateUserOfficialScores(ctx, year, userID)
+
+		assert.ErrorIs(t, err, rebuildErr)
+		require.Len(t, store.rebuildOfficialCalls, 1)
 	})
 }


### PR DESCRIPTION
## Summary

- rebuild the current-year and global official leaderboards when the outbox worker starts
- propagate leaderboard cache update failures so outbox events remain pending for retry
- preserve deduplication while acknowledging permanently malformed events
- add regression coverage for failed updates, duplicate groups, partial success, malformed events, and startup reconciliation

## Production diagnosis

The unfiltered 2026 leaderboard matched January's contest results, while database-backed filtered queries included later contests. The persisted Valkey rebuild markers for the 2026 and global leaderboards were still dated February 14, so recreating the API and Valkey workloads in August continued serving an old snapshot without reconciling it.

## Verification

- `bazel build //services/...`
- `bazel test //services/...`
- `bazel test //services/immersion-api/... --test_output=errors`
- `git diff --check`
