### PR TITLE
Add immersion account deletion state columns

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0025_account_deletion_state.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0025_account_deletion_state.down.sql
@@ -1,0 +1,7 @@
+begin;
+
+alter table logs drop column frozen_at;
+alter table users drop column deleted_at;
+alter table users drop column deletion_locked_at;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0025_account_deletion_state.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0025_account_deletion_state.up.sql
@@ -1,0 +1,7 @@
+begin;
+
+alter table users add column deletion_locked_at timestamp;
+alter table users add column deleted_at timestamp;
+alter table logs add column frozen_at timestamp;
+
+commit;

--- a/services/immersion-api/storage/postgres/models.go
+++ b/services/immersion-api/storage/postgres/models.go
@@ -94,6 +94,7 @@ type Log struct {
 	ScoreRuleIds                []uuid.UUID
 	ScoreRates                  []float32
 	ScoreSource                 sql.NullString
+	FrozenAt                    sql.NullTime
 }
 
 type LogTag struct {
@@ -152,10 +153,12 @@ type ScoringRuleSet struct {
 }
 
 type User struct {
-	ID          uuid.UUID
-	DisplayName string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID               uuid.UUID
+	DisplayName      string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	DeletionLockedAt sql.NullTime
+	DeletedAt        sql.NullTime
 }
 
 type UserRole struct {


### PR DESCRIPTION
## Summary

- add nullable `users.deletion_locked_at` and `users.deleted_at` columns
- add nullable `logs.frozen_at`
- include the complete sqlc-generated model update required by the new nullable columns
- keep the migration additive and compatible with the currently deployed immersion service
- include a down migration; no application runtime behavior depends on these columns yet

## Validation

- applied the complete immersion migration chain to a fresh PostgreSQL instance
- verified all three columns are present after migration 0025
- rolled migration 0025 down and verified all three columns are removed
- `./scripts/generate-sqlc.sh` leaves the worktree clean
- `bazel build //services/immersion-api/...`
- `bazel build //services/immersion-api/storage/postgres/migrations:tar`
- `bazel test //services/common/migrate-recovery:migrate-recovery_test`
- `bazel run //:gazelle -- -mode=diff`

## Deployment order

Deploy and verify this migration independently while the current immersion service remains running. Runtime behavior that uses these columns must be based on updated `main` only after this PR is merged and deployed.

**Posted by gpt-5.6-sol**
