### PR TITLE
Prevent duplicate registration languages

### DIFF
--- a/frontend/apps/webv2/app/immersion/ContestRegistration.test.ts
+++ b/frontend/apps/webv2/app/immersion/ContestRegistration.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: { apiEndpoint: '' } }),
+}))
+
+import { ContestRegistrationFormSchema } from './ContestRegistration'
+
+describe('ContestRegistrationFormSchema', () => {
+  it('rejects duplicate language codes', () => {
+    const result = ContestRegistrationFormSchema.safeParse({
+      contest_id: 'contest-id',
+      new_languages: [
+        { code: 'jpn', name: 'Japanese' },
+        { code: 'jpn', name: 'Duplicate display name' },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Cannot select the same language more than once',
+          }),
+        ]),
+      )
+    }
+  })
+
+  it('accepts one to three unique language codes', () => {
+    for (const newLanguages of [
+      [{ code: 'jpn', name: 'Japanese' }],
+      [
+        { code: 'jpn', name: 'Japanese' },
+        { code: 'kor', name: 'Korean' },
+      ],
+      [
+        { code: 'jpn', name: 'Japanese' },
+        { code: 'kor', name: 'Korean' },
+        { code: 'zho', name: 'Chinese' },
+      ],
+    ]) {
+      const result = ContestRegistrationFormSchema.safeParse({
+        contest_id: 'contest-id',
+        new_languages: newLanguages,
+      })
+
+      expect(result.success).toBe(true)
+    }
+  })
+})

--- a/frontend/apps/webv2/app/immersion/ContestRegistration.tsx
+++ b/frontend/apps/webv2/app/immersion/ContestRegistration.tsx
@@ -26,7 +26,13 @@ export const ContestRegistrationFormSchema = z.object({
       }),
     )
     .max(3, 'Cannot select more than 3 languages')
-    .min(1, 'Must select at least 1 languages'),
+    .min(1, 'Must select at least 1 languages')
+    .refine(
+      languages =>
+        new Set(languages.map(language => language.code)).size ===
+        languages.length,
+      'Cannot select the same language more than once',
+    ),
   languages: z
     .array(
       z.object({

--- a/services/immersion-api/domain/registrationupsert.go
+++ b/services/immersion-api/domain/registrationupsert.go
@@ -85,6 +85,14 @@ func (s *RegistrationUpsert) Execute(ctx context.Context, req *RegistrationUpser
 		return fmt.Errorf("invalid language code length: %w", ErrInvalidContestRegistration)
 	}
 
+	languageCodes := make(map[string]struct{}, len(req.LanguageCodes))
+	for _, code := range req.LanguageCodes {
+		if _, exists := languageCodes[code]; exists {
+			return fmt.Errorf("duplicate language code %s: %w", code, ErrInvalidContestRegistration)
+		}
+		languageCodes[code] = struct{}{}
+	}
+
 	exists, err := s.repo.LanguagesExist(ctx, req.LanguageCodes)
 	if err != nil {
 		return fmt.Errorf("could not check whether languages exist: %w", err)

--- a/services/immersion-api/domain/registrationupsert_test.go
+++ b/services/immersion-api/domain/registrationupsert_test.go
@@ -160,6 +160,31 @@ func TestRegistrationUpsert_Execute(t *testing.T) {
 		assert.False(t, repo.upsertCalled)
 	})
 
+	t.Run("rejects duplicate language codes without changing registration data", func(t *testing.T) {
+		userRepo := &mockUserUpsertRepositoryForReg{}
+		userUpsert := domain.NewUserUpsert(userRepo)
+		repo := &mockRegistrationUpsertRepository{
+			contest: validContest,
+			registration: &domain.ContestRegistration{
+				ID:        uuid.New(),
+				ContestID: contestID,
+				UserID:    userID,
+				Languages: []domain.Language{{Code: "kor", Name: "Korean"}},
+			},
+		}
+		svc := domain.NewRegistrationUpsert(repo, userUpsert)
+
+		err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.RegistrationUpsertRequest{
+			ContestID:     contestID,
+			LanguageCodes: []string{"jpn", "jpn"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrInvalidContestRegistration)
+		assert.Empty(t, repo.languageBatches)
+		assert.False(t, repo.detachCalled)
+		assert.False(t, repo.upsertCalled)
+	})
+
 	t.Run("returns error when language not allowed by contest", func(t *testing.T) {
 		userRepo := &mockUserUpsertRepositoryForReg{}
 		userUpsert := domain.NewUserUpsert(userRepo)


### PR DESCRIPTION
Closes #78.

## Summary

- reject duplicate language codes in `RegistrationUpsert` before language lookup, log detachment, or registration persistence
- add matching form-schema validation with a clear user-facing error
- preserve support for one to three unique registration languages
- add backend and frontend regression coverage

No database migration, SQLC generation, or OpenAPI change is required.

## Validation

- `bazel build //services/...`
- `bazel test //services/...` — 20/20 test targets passed
- `bazel run //:gazelle -- -mode=diff`
- `pnpm --filter webv2 test -- ContestRegistration.test.ts` — 5 files / 14 tests passed
- `pnpm --filter webv2 lint`
- `pnpm --filter webv2 build`
- `git diff --check`

## Note

Standalone `pnpm --filter webv2 exec tsc --noEmit` still reports the existing UI-package SVG module-resolution errors for `logo.svg` and `logo-light.svg`; the production Next build compiled and completed its type validation successfully.