### PR TITLE
Seed Tilt Flipt from canonical feature flags

### DIFF
--- a/infra/dev/flipt/BUILD.bazel
+++ b/infra/dev/flipt/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "flipt_test",
+    srcs = ["flipt_test.go"],
+    data = [
+        "Tiltfile",
+        "flipt.yaml",
+        "seed/default/features.yaml",
+        "//:feature-flags.contract.json",
+    ],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel",
+    ],
+)

--- a/infra/dev/flipt/README.md
+++ b/infra/dev/flipt/README.md
@@ -1,15 +1,24 @@
 # Flipt development
 
 The local Flipt deployment is deliberately separate from production. It has a
-single `local` environment backed only by Flipt's in-memory storage. It has no
-Git remote or credential, persistent volume, database, or cache, and its pod is
-not allowed general internet egress.
+single `local` environment backed by a writable Git repository on a
+memory-backed `emptyDir`. It has no Git remote or credential, persistent
+volume, database, or cache, and its pod is not allowed general internet
+egress.
 
-Local flag state is disposable. Restarting or replacing the Flipt pod may
-return it to an empty state. Developers create the flags they need through the
-Oathkeeper-protected local Flipt UI; the repository does not seed or promote
-local flag definitions. Tadoku applications must remain usable with their
-compiled safe defaults when that state is empty or unavailable.
+Tilt initializes that repository from the canonical definitions under
+`infra/dev/flipt/seed/`. The seed contains every application-registered flag
+at its compiled safe default. Developers can change flags through the
+Oathkeeper-protected UI while the pod is running; replacing the pod discards
+those edits and restores the committed seed. Changing the seed checksum also
+changes the pod template, so Tilt replaces Flipt and reruns initialization.
+Tadoku applications must still remain usable with their compiled safe defaults
+when Flipt is unavailable.
+
+The bootstrap init container contains Git and creates the disposable local
+repository before Flipt starts. The main Flipt image is not expected to contain
+Git. Both images and the init container's restricted security context are
+pinned in `flipt.yaml`.
 
 Prometheus-format metrics are available to the cluster monitoring workload at
 `/metrics`. The Service is cluster-internal, and NetworkPolicies accept Flipt

--- a/infra/dev/flipt/Tiltfile
+++ b/infra/dev/flipt/Tiltfile
@@ -1,13 +1,54 @@
 # -*- mode: Python -*-
 
-load('./../../../k8s/dev/config/Tiltfile', 'render_template')
+load('./../../../k8s/dev/config/Tiltfile', 'render_template', 'repo_path')
+
+seed_path = repo_path('infra/dev/flipt/seed/default/features.yaml')
+# Register the canonical seed as a Tilt dependency so edits re-evaluate this
+# include, refresh the checksum annotation, and replace the Flipt pod.
+read_file(seed_path)
+seed_checksum = str(local(
+    [
+        'python3',
+        '-c',
+        'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())',
+        seed_path,
+    ],
+    quiet=True,
+)).strip()
+seed_base64 = str(local(
+    [
+        'python3',
+        '-c',
+        'import base64, pathlib, sys; print(base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()).decode())',
+        seed_path,
+    ],
+    quiet=True,
+)).strip()
+
+flipt_manifest = str(read_file('./flipt.yaml')).replace(
+    '__FLIPT_SEED_SHA256__',
+    seed_checksum,
+)
+seed_manifest = '''
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flipt-seed
+  namespace: tdk-flipt
+  labels:
+    app.kubernetes.io/name: flipt
+    app.kubernetes.io/part-of: tadoku
+binaryData:
+  features.yaml: {seed_base64}
+'''.format(seed_base64=seed_base64)
 
 flipt_ingress = render_template(
     'infra/dev/flipt/ingress.yaml',
     '.tilt/rendered/infra/dev/flipt/ingress.yaml',
 )
 
-k8s_yaml('./flipt.yaml')
+k8s_yaml(blob(flipt_manifest))
+k8s_yaml(blob(seed_manifest))
 k8s_yaml(flipt_ingress)
 
 k8s_resource(
@@ -25,6 +66,7 @@ k8s_resource(
     objects=[
         'flipt:serviceaccount:tdk-flipt',
         'flipt:configmap:tdk-flipt',
+        'flipt-seed:configmap:tdk-flipt',
     ],
     new_name='flipt-config',
     labels=['infra'],

--- a/infra/dev/flipt/flipt.yaml
+++ b/infra/dev/flipt/flipt.yaml
@@ -41,13 +41,17 @@ data:
       grpc_port: 9000
     storage:
       local:
+        name: local
+        branch: main
         backend:
-          type: memory
+          type: local
+          path: /var/lib/flipt
     environments:
       local:
         name: local
         default: true
         storage: local
+        directory: default
     metrics:
       enabled: true
       exporter: prometheus
@@ -81,6 +85,8 @@ spec:
       app.kubernetes.io/name: flipt
   template:
     metadata:
+      annotations:
+        tadoku.dev/flipt-seed-sha256: __FLIPT_SEED_SHA256__
       labels:
         app.kubernetes.io/name: flipt
         app.kubernetes.io/part-of: tadoku
@@ -96,6 +102,57 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: initialize-seed
+          image: docker.io/alpine/git:2.47.2@sha256:062a01ad7a0eb17cff382bc5e26086b4d710e56dfdfdf001109a49b6d9bd378c
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              mkdir -p /var/lib/flipt/default
+              cp -R /seed/. /var/lib/flipt/default/
+              chmod 0644 /var/lib/flipt/default/features.yaml
+              cd /var/lib/flipt
+              git init --initial-branch=main
+              git config --global --add safe.directory /var/lib/flipt
+              git config user.name "Tadoku Tilt"
+              git config user.email "tilt@tadoku.local"
+              git add default/features.yaml
+              git commit -m "Initialize canonical local feature flags"
+          env:
+            - name: HOME
+              value: /tmp
+            - name: TMPDIR
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 100
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: seed
+              mountPath: /seed
+              readOnly: true
+            - name: repository
+              mountPath: /var/lib/flipt
+            - name: tmp
+              mountPath: /tmp
       containers:
         - name: flipt
           image: docker.flipt.io/flipt/flipt:v2.11.0@sha256:d20384874048ef6ac326f4937cee64f1db175a1878a87db32916cc8db46c740e
@@ -164,6 +221,8 @@ spec:
               readOnly: true
             - name: state
               mountPath: /home/flipt/.config/flipt
+            - name: repository
+              mountPath: /var/lib/flipt
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -171,6 +230,14 @@ spec:
           configMap:
             name: flipt
             defaultMode: 0444
+        - name: seed
+          configMap:
+            name: flipt-seed
+            defaultMode: 0444
+        - name: repository
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Mi
         - name: state
           emptyDir:
             medium: Memory

--- a/infra/dev/flipt/flipt_test.go
+++ b/infra/dev/flipt/flipt_test.go
@@ -1,0 +1,89 @@
+package flipt_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type featureContract struct {
+	BooleanFlags map[string]struct {
+		SafeDefault bool `json:"safeDefault"`
+	} `json:"booleanFlags"`
+}
+
+func TestSeedMatchesApplicationContract(t *testing.T) {
+	contractContents := readRunfile(t, "feature-flags.contract.json")
+	var contract featureContract
+	require.NoError(t, json.Unmarshal(contractContents, &contract))
+
+	seed := string(readRunfile(t, "infra/dev/flipt/seed/default/features.yaml"))
+	assert.Contains(t, seed, "version: \"1.4\"")
+	assert.Contains(t, seed, "namespace:\n  key: default")
+	assert.Equal(t, len(contract.BooleanFlags), strings.Count(seed, "\n  - key: "))
+
+	for key, definition := range contract.BooleanFlags {
+		pattern := regexp.MustCompile(
+			`(?m)^  - key: ` + regexp.QuoteMeta(key) +
+				`\n(?:    [^\n]+\n)*?    type: BOOLEAN_FLAG_TYPE` +
+				`\n(?:    [^\n]+\n)*?    enabled: (true|false)$`,
+		)
+		match := pattern.FindStringSubmatch(seed)
+		require.Len(t, match, 2, "seed must define boolean contract flag %q", key)
+		assert.Equal(t, definition.SafeDefault, match[1] == "true")
+	}
+}
+
+func TestDeploymentBootstrapsRestrictedDisposableGitRepository(t *testing.T) {
+	manifest := string(readRunfile(t, "infra/dev/flipt/flipt.yaml"))
+
+	assert.Contains(t, manifest, "tadoku.dev/flipt-seed-sha256: __FLIPT_SEED_SHA256__")
+	assert.Contains(t, manifest, "image: docker.io/alpine/git:2.47.2@sha256:")
+	assert.Contains(t, manifest, "git init --initial-branch=main")
+	assert.Contains(t, manifest, "chmod 0644 /var/lib/flipt/default/features.yaml")
+	assert.Contains(t, manifest, "git config --global --add safe.directory /var/lib/flipt")
+	assert.Contains(t, manifest, "git add default/features.yaml")
+	assert.Contains(t, manifest, "name: seed\n              mountPath: /seed\n              readOnly: true")
+	assert.Contains(t, manifest, "name: seed\n          configMap:\n            name: flipt-seed")
+	assert.Contains(t, manifest, "name: repository\n          emptyDir:\n            medium: Memory")
+	assert.Contains(t, manifest, "name: repository\n              mountPath: /var/lib/flipt")
+	assert.Contains(t, manifest, "allowPrivilegeEscalation: false")
+	assert.Contains(t, manifest, "readOnlyRootFilesystem: true")
+	assert.Contains(t, manifest, "runAsNonRoot: true")
+	assert.Contains(t, manifest, "seccompProfile:\n              type: RuntimeDefault")
+	assert.NotContains(t, manifest, "persistentVolumeClaim:")
+}
+
+func TestFliptUsesLocalSeededStorageWithoutRemote(t *testing.T) {
+	manifest := string(readRunfile(t, "infra/dev/flipt/flipt.yaml"))
+	assert.Contains(t, manifest, "type: local\n          path: /var/lib/flipt")
+	assert.Contains(t, manifest, "branch: main")
+	assert.Contains(t, manifest, "directory: default")
+	assert.NotContains(t, manifest, "remote:")
+
+	tiltfile := string(readRunfile(t, "infra/dev/flipt/Tiltfile"))
+	assert.Contains(t, tiltfile, "read_file(seed_path)")
+	assert.Contains(t, tiltfile, "__FLIPT_SEED_SHA256__")
+	assert.Contains(t, tiltfile, "binaryData:")
+
+	seed := readRunfile(t, "infra/dev/flipt/seed/default/features.yaml")
+	digest := sha256.Sum256(seed)
+	assert.Len(t, hex.EncodeToString(digest[:]), 64)
+}
+
+func readRunfile(t *testing.T, path string) []byte {
+	t.Helper()
+	resolved, err := bazel.Runfile(path)
+	require.NoError(t, err)
+	contents, err := os.ReadFile(resolved)
+	require.NoError(t, err)
+	return contents
+}

--- a/infra/dev/flipt/seed/default/features.yaml
+++ b/infra/dev/flipt/seed/default/features.yaml
@@ -1,0 +1,10 @@
+version: "1.4"
+namespace:
+  key: default
+  name: Default
+flags:
+  - key: release-log-entry-v2
+    name: Release log entry v2
+    type: BOOLEAN_FLAG_TYPE
+    description: Use the second-generation log entry flow.
+    enabled: false

--- a/services/immersion-api/Tiltfile
+++ b/services/immersion-api/Tiltfile
@@ -10,4 +10,15 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('immersion-api', labels=["backend"], resource_deps=["tadoku-dev-db-credentials", "kratos", "keto", "valkey-immersion"])
+k8s_resource(
+  'immersion-api',
+  labels=["backend"],
+  resource_deps=[
+    "tadoku-dev-db-credentials",
+    "flipt",
+    "kratos",
+    "keto",
+    "oathkeeper",
+    "valkey-immersion",
+  ],
+)


### PR DESCRIPTION
## Summary

- add a canonical Tilt-only Flipt seed for `release-log-entry-v2`, disabled at its safe default
- bootstrap a writable, disposable local Git repository from the read-only seed with a restricted digest-pinned Git init container
- include the seed checksum in the Flipt pod template so seed edits replace the pod and restore canonical state
- keep runtime UI edits writable for the pod lifetime while pod replacement resets them
- make immersion-api wait for Flipt and Oathkeeper in Tilt
- document the lifecycle and test seed/contract plus deployment security invariants

## Scope and safety

This changes only the Tilt development deployment. It does not seed production, configure a Git remote, or add credentials or persistent storage. The repository remains memory-backed and Flipt egress remains restricted to DNS.

## Validation

- `bazel test //infra/dev/flipt:flipt_test //services/common/featureflags:featureflags_test`
- `bazel run //:gazelle -- -mode=diff`
- pinned Flipt v2.11.0: `/flipt validate --work-dir /seed --format text`
- full root Tiltfile evaluation with a local configuration
- rendered Flipt resources: `kubectl create --dry-run=client --validate=false -f -`
- restricted init-container smoke test as UID 100/GID 1000, including Git commit and writable `0644` seeded file