### PR TITLE
Fix local Flipt seed bootstrap

### DIFF
--- a/infra/dev/flipt/flipt.yaml
+++ b/infra/dev/flipt/flipt.yaml
@@ -51,7 +51,6 @@ data:
         name: local
         default: true
         storage: local
-        directory: default
     metrics:
       enabled: true
       exporter: prometheus
@@ -112,7 +111,7 @@ spec:
           args:
             - |
               mkdir -p /var/lib/flipt/default
-              cp -R /seed/. /var/lib/flipt/default/
+              cp -L /seed/features.yaml /var/lib/flipt/default/features.yaml
               chmod 0644 /var/lib/flipt/default/features.yaml
               cd /var/lib/flipt
               git init --initial-branch=main

--- a/infra/dev/flipt/flipt_test.go
+++ b/infra/dev/flipt/flipt_test.go
@@ -47,6 +47,8 @@ func TestDeploymentBootstrapsRestrictedDisposableGitRepository(t *testing.T) {
 
 	assert.Contains(t, manifest, "tadoku.dev/flipt-seed-sha256: __FLIPT_SEED_SHA256__")
 	assert.Contains(t, manifest, "image: docker.io/alpine/git:2.47.2@sha256:")
+	assert.Contains(t, manifest, "cp -L /seed/features.yaml /var/lib/flipt/default/features.yaml")
+	assert.NotContains(t, manifest, "cp -R /seed/. /var/lib/flipt/default/")
 	assert.Contains(t, manifest, "git init --initial-branch=main")
 	assert.Contains(t, manifest, "chmod 0644 /var/lib/flipt/default/features.yaml")
 	assert.Contains(t, manifest, "git config --global --add safe.directory /var/lib/flipt")
@@ -66,7 +68,7 @@ func TestFliptUsesLocalSeededStorageWithoutRemote(t *testing.T) {
 	manifest := string(readRunfile(t, "infra/dev/flipt/flipt.yaml"))
 	assert.Contains(t, manifest, "type: local\n          path: /var/lib/flipt")
 	assert.Contains(t, manifest, "branch: main")
-	assert.Contains(t, manifest, "directory: default")
+	assert.NotContains(t, manifest, "directory: default")
 	assert.NotContains(t, manifest, "remote:")
 
 	tiltfile := string(readRunfile(t, "infra/dev/flipt/Tiltfile"))


### PR DESCRIPTION
## Summary

- dereference the Kubernetes ConfigMap seed into a regular file before committing it
- let the local environment scan the repository root so `default/features.yaml` is discovered
- add regression assertions for both bootstrap failures

## Verification

- `bazel test //infra/dev/flipt:flipt_test --test_output=errors`
- all 31 Tilt resources healthy
- live Flipt snapshot endpoint returns 200 with `release-log-entry-v2=false`
- immersion-api snapshot refresh returns gRPC `OK`