### PR TITLE
Fix S2S token refresh for Flipt polling

### DIFF
--- a/services/token-reflector/BUILD.bazel
+++ b/services/token-reflector/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -7,12 +7,24 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/tadoku/tadoku/services/token-reflector",
     visibility = ["//visibility:private"],
+    deps = ["//services/common/domain"],
 )
 
 go_binary(
     name = "token-reflector",
     embed = [":token-reflector_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "token-reflector_test",
+    srcs = ["main_test.go"],
+    embed = [":token-reflector_lib"],
+    deps = [
+        "//services/common/domain",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 pkg_tar(

--- a/services/token-reflector/main.go
+++ b/services/token-reflector/main.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	commondomain "github.com/tadoku/tadoku/services/common/domain"
 )
 
 type TokenResponse struct {
@@ -24,28 +28,16 @@ type JWKSProxy struct {
 	token  string
 }
 
+var errExpiredToken = errors.New("token is expired")
+
 func main() {
 	jwksProxy := newJWKSProxy()
+	clock, err := commondomain.NewClock("UTC")
+	if err != nil {
+		panic(err)
+	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		token := r.Header.Get("X-Id-Token")
-		if token == "" {
-			auth := r.Header.Get("Authorization")
-			if strings.HasPrefix(auth, "Bearer ") {
-				token = strings.TrimPrefix(auth, "Bearer ")
-			}
-		}
-		if token == "" {
-			http.Error(w, "missing X-Id-Token header", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(TokenResponse{
-			AccessToken: token,
-			TokenType:   "Bearer",
-			ExpiresIn:   3600,
-		})
-	})
+	http.Handle("/", newTokenHandler(clock))
 
 	http.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
 		body, err := jwksProxy.Fetch(r.Context())
@@ -68,6 +60,73 @@ func main() {
 	}
 
 	_ = http.ListenAndServe(":"+port, nil)
+}
+
+func newTokenHandler(clock commondomain.Clock) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("X-Id-Token")
+		if token == "" {
+			auth := r.Header.Get("Authorization")
+			if strings.HasPrefix(auth, "Bearer ") {
+				token = strings.TrimPrefix(auth, "Bearer ")
+			}
+		}
+		if token == "" {
+			http.Error(w, "missing X-Id-Token header", http.StatusBadRequest)
+			return
+		}
+
+		expiresIn, err := tokenExpiresIn(token, clock.Now())
+		if err != nil {
+			if errors.Is(err, errExpiredToken) {
+				http.Error(w, "token is expired", http.StatusUnauthorized)
+				return
+			}
+			http.Error(w, "token has an invalid expiry", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: token,
+			TokenType:   "Bearer",
+			ExpiresIn:   expiresIn,
+		})
+	})
+}
+
+func tokenExpiresIn(token string, now time.Time) (int, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("token must have three segments")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0, fmt.Errorf("decode token payload: %w", err)
+	}
+
+	var claims struct {
+		ExpiresAt json.Number `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return 0, fmt.Errorf("decode token claims: %w", err)
+	}
+	if claims.ExpiresAt == "" {
+		return 0, fmt.Errorf("token is missing exp claim")
+	}
+
+	expiresAt, err := claims.ExpiresAt.Int64()
+	if err != nil {
+		return 0, fmt.Errorf("decode exp claim: %w", err)
+	}
+
+	remaining := time.Unix(expiresAt, 0).Sub(now)
+	if remaining <= 0 {
+		return 0, errExpiredToken
+	}
+
+	return int(remaining / time.Second), nil
 }
 
 func newJWKSProxy() *JWKSProxy {

--- a/services/token-reflector/main_test.go
+++ b/services/token-reflector/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commondomain "github.com/tadoku/tadoku/services/common/domain"
+)
+
+func TestTokenResponseUsesReflectedJWTExpiry(t *testing.T) {
+	now := time.Date(2026, 8, 31, 16, 0, 0, 0, time.UTC)
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, now.Add(15*time.Minute).Unix())))
+	token := "header." + payload + ".signature"
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Id-Token", token)
+	recorder := httptest.NewRecorder()
+
+	newTokenHandler(commondomain.NewMockClock(now)).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var response TokenResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	assert.Equal(t, token, response.AccessToken)
+	assert.Equal(t, "Bearer", response.TokenType)
+	assert.Equal(t, 900, response.ExpiresIn)
+}


### PR DESCRIPTION
## Summary

- derive the reflected OAuth `expires_in` value from the Oathkeeper JWT `exp` claim
- inject the common clock so expiry handling is deterministic and testable
- reject malformed or expired reflected tokens instead of advertising an incorrect lifetime

## Why

Oathkeeper issues the callback JWT with a 15-minute lifetime, but token-reflector advertised a fixed one-hour lifetime. The S2S client therefore cached the token after it expired, and immersion-api feature-flag polling remained on stale fallback decisions until restart.

## Verification

- `bazel test //services/token-reflector:token-reflector_test //services/common/client/s2s:s2s_test`
- `bazel build //services/token-reflector/...`
- `bazel run //:gazelle -- -mode=diff`
- `git diff --check`
- rebuilt token-reflector in Tilt and recycled the disposable immersion-api pod
- verified provider configuration age becomes fresh
- verified targeted dev admin gets `release-log-entry-v2: true` while the ordinary seeded reader gets `false`