### PR TITLE
Gate the V2 log journey with Flipt

### DIFF
--- a/frontend/apps/webv2/app/feature-flags/bootstrap.test.ts
+++ b/frontend/apps/webv2/app/feature-flags/bootstrap.test.ts
@@ -5,6 +5,9 @@ import { bootstrapFeatureFlagDecisions } from './bootstrap'
 vi.mock('next/config', () => ({
   default: () => ({
     publicRuntimeConfig: { apiEndpoint: 'https://tadoku.test/api/internal' },
+    serverRuntimeConfig: {
+      apiEndpoint: 'http://oathkeeper-proxy:4455/api/internal',
+    },
   }),
 }))
 
@@ -32,7 +35,7 @@ describe('bootstrapFeatureFlagDecisions', () => {
       ),
     ).resolves.toEqual({ 'release-log-entry-v2': true })
     expect(request).toHaveBeenCalledWith(
-      'https://tadoku.test/api/internal/immersion/feature-flags',
+      'http://oathkeeper-proxy:4455/api/internal/immersion/feature-flags',
       {
         cache: 'no-store',
         headers: { cookie: 'ory_kratos_session=secret' },
@@ -85,7 +88,7 @@ describe('bootstrapFeatureFlagDecisions', () => {
 
     await expect(result).resolves.toEqual({ 'release-log-entry-v2': false })
     expect(request).toHaveBeenCalledWith(
-      'https://tadoku.test/api/internal/immersion/feature-flags',
+      'http://oathkeeper-proxy:4455/api/internal/immersion/feature-flags',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     vi.useRealTimers()

--- a/frontend/apps/webv2/app/feature-flags/bootstrap.ts
+++ b/frontend/apps/webv2/app/feature-flags/bootstrap.ts
@@ -7,8 +7,10 @@ import {
 } from './registry'
 import type { FeatureFlagDecisions } from './registry'
 
-const { publicRuntimeConfig } = getConfig()
-const featureFlagEndpoint = `${publicRuntimeConfig.apiEndpoint}/immersion/feature-flags`
+const { publicRuntimeConfig, serverRuntimeConfig } = getConfig()
+const featureFlagEndpoint = `${
+  serverRuntimeConfig?.apiEndpoint ?? publicRuntimeConfig.apiEndpoint
+}/immersion/feature-flags`
 
 export const bootstrapFeatureFlagDecisions = async (
   session: Session | undefined,

--- a/frontend/apps/webv2/app/feature-flags/client.test.tsx
+++ b/frontend/apps/webv2/app/feature-flags/client.test.tsx
@@ -43,16 +43,8 @@ const FlagValue = () => {
   return <output>{enabled ? 'enabled' : 'disabled'}</output>
 }
 
-const LatchedFlagValue = ({
-  enabledOverride = false,
-}: {
-  enabledOverride?: boolean
-}) => {
-  const enabled = useLatchedFeatureFlag(
-    'release-log-entry-v2',
-    true,
-    enabledOverride,
-  )
+const LatchedFlagValue = () => {
+  const enabled = useLatchedFeatureFlag('release-log-entry-v2')
   const setDecisions = useSetAtom(featureFlagDecisionsAtom)
 
   return (
@@ -145,16 +137,6 @@ describe('feature flag browser state', () => {
     )
 
     expect(screen.getByText('latched disabled')).toBeTruthy()
-  })
-
-  it('allows an existing behavior to override a disabled flag', () => {
-    render(
-      <Wrapper>
-        <LatchedFlagValue enabledOverride />
-      </Wrapper>,
-    )
-
-    expect(screen.getByLabelText('V2 draft')).toBeTruthy()
   })
 
   it('uses the legacy default while refreshing after navigation without remounting a form', async () => {

--- a/frontend/apps/webv2/app/feature-flags/client.test.tsx
+++ b/frontend/apps/webv2/app/feature-flags/client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { Provider } from 'jotai'
+import { Provider, useSetAtom } from 'jotai'
 import {
   act,
   cleanup,
@@ -15,6 +15,7 @@ import {
   FeatureFlagRefresh,
   featureFlagDecisionsAtom,
   useFeatureFlag,
+  useLatchedFeatureFlag,
 } from './client'
 
 const routerEvents = vi.hoisted(() => {
@@ -40,6 +41,38 @@ vi.mock('next/config', () => ({
 const FlagValue = () => {
   const enabled = useFeatureFlag('release-log-entry-v2')
   return <output>{enabled ? 'enabled' : 'disabled'}</output>
+}
+
+const LatchedFlagValue = ({
+  enabledOverride = false,
+}: {
+  enabledOverride?: boolean
+}) => {
+  const enabled = useLatchedFeatureFlag(
+    'release-log-entry-v2',
+    true,
+    enabledOverride,
+  )
+  const setDecisions = useSetAtom(featureFlagDecisionsAtom)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setDecisions({ 'release-log-entry-v2': false })}
+      >
+        Disable
+      </button>
+      {enabled ? (
+        <label>
+          V2 draft
+          <input defaultValue="before decision change" />
+        </label>
+      ) : (
+        <output>latched disabled</output>
+      )}
+    </>
+  )
 }
 
 const Wrapper = ({
@@ -88,6 +121,40 @@ describe('feature flag browser state', () => {
     )
 
     expect(screen.getByText('disabled')).toBeTruthy()
+  })
+
+  it('keeps a mounted feature flow stable until the next mount', () => {
+    const mounted = render(
+      <Wrapper enabled>
+        <LatchedFlagValue />
+      </Wrapper>,
+    )
+
+    const input = screen.getByLabelText('V2 draft') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'unsaved form value' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+
+    expect(input.value).toBe('unsaved form value')
+    expect(screen.getByLabelText('V2 draft')).toBe(input)
+    mounted.unmount()
+
+    render(
+      <Wrapper>
+        <LatchedFlagValue />
+      </Wrapper>,
+    )
+
+    expect(screen.getByText('latched disabled')).toBeTruthy()
+  })
+
+  it('allows an existing behavior to override a disabled flag', () => {
+    render(
+      <Wrapper>
+        <LatchedFlagValue enabledOverride />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText('V2 draft')).toBeTruthy()
   })
 
   it('uses the legacy default while refreshing after navigation without remounting a form', async () => {

--- a/frontend/apps/webv2/app/feature-flags/client.tsx
+++ b/frontend/apps/webv2/app/feature-flags/client.tsx
@@ -21,14 +21,12 @@ export const useFeatureFlag = (flag: FeatureFlagKey) =>
 
 export const useLatchedFeatureFlag = (
   flag: FeatureFlagKey,
-  ready = true,
-  enabledOverride = false,
-): boolean | undefined => {
+): boolean => {
   const enabled = useFeatureFlag(flag)
   const latched = useRef<boolean>()
 
-  if (ready && latched.current === undefined) {
-    latched.current = enabledOverride || enabled
+  if (latched.current === undefined) {
+    latched.current = enabled
   }
 
   return latched.current

--- a/frontend/apps/webv2/app/feature-flags/client.tsx
+++ b/frontend/apps/webv2/app/feature-flags/client.tsx
@@ -1,7 +1,7 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import getConfig from 'next/config'
 import { useRouter } from 'next/router'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import {
   defaultFeatureFlagDecisions,
@@ -18,6 +18,21 @@ export const featureFlagDecisionsAtom = atom<FeatureFlagDecisions>({
 
 export const useFeatureFlag = (flag: FeatureFlagKey) =>
   useAtomValue(featureFlagDecisionsAtom)[flag]
+
+export const useLatchedFeatureFlag = (
+  flag: FeatureFlagKey,
+  ready = true,
+  enabledOverride = false,
+): boolean | undefined => {
+  const enabled = useFeatureFlag(flag)
+  const latched = useRef<boolean>()
+
+  if (ready && latched.current === undefined) {
+    latched.current = enabledOverride || enabled
+  }
+
+  return latched.current
+}
 
 export const FeatureFlagRefresh = ({
   children,

--- a/frontend/apps/webv2/app/immersion/log-feature-flag-pages.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-feature-flag-pages.test.tsx
@@ -10,14 +10,12 @@ const {
   useLog,
   useLogConfigurationOptions,
   useOngoingContestRegistrations,
-  useUserRole,
 } = vi.hoisted(() => ({
   featureDecision: { enabled: false },
   useLatchedFeatureFlag: vi.fn(),
   useLog: vi.fn(),
   useLogConfigurationOptions: vi.fn(),
   useOngoingContestRegistrations: vi.fn(),
-  useUserRole: vi.fn(),
 }))
 
 vi.mock('@app/feature-flags/client', () => ({ useLatchedFeatureFlag }))
@@ -25,7 +23,6 @@ vi.mock('@app/feature-flags/client', () => ({ useLatchedFeatureFlag }))
 vi.mock('@app/common/session', () => ({
   useSession: () => [{ identity: { id: 'user-id' } }],
   useSessionOrRedirect: vi.fn(),
-  useUserRole,
 }))
 
 vi.mock('@app/common/hooks', () => ({
@@ -137,14 +134,9 @@ describe('release-log-entry-v2 pages', () => {
     useLog.mockReset()
     useLogConfigurationOptions.mockReset()
     useOngoingContestRegistrations.mockReset()
-    useUserRole.mockReset()
 
     featureDecision.enabled = false
-    useLatchedFeatureFlag.mockImplementation(
-      (_flag: string, _ready: boolean, enabledOverride = false) =>
-        enabledOverride || featureDecision.enabled,
-    )
-    useUserRole.mockReturnValue('user')
+    useLatchedFeatureFlag.mockImplementation(() => featureDecision.enabled)
     useLogConfigurationOptions.mockReturnValue(optionsResult)
     useOngoingContestRegistrations.mockReturnValue(registrationsResult)
     useLog.mockReturnValue({
@@ -164,20 +156,6 @@ describe('release-log-entry-v2 pages', () => {
     const details = renderToStaticMarkup(<LogDetailsPage />)
     expect(details).toContain('Log details')
     expect(details).not.toContain('v2 log details')
-  })
-
-  it('preserves the existing V2 journey for admins when the flag is disabled', () => {
-    useUserRole.mockReturnValue('admin')
-
-    expect(renderToStaticMarkup(<NewLogPage />)).toContain('v2 create form')
-    expect(renderToStaticMarkup(<LogDetailsPage />)).toContain('v2 log details')
-    expect(renderToStaticMarkup(<EditLogPage />)).toContain('v2 edit form')
-
-    expect(useLatchedFeatureFlag).toHaveBeenCalledWith(
-      'release-log-entry-v2',
-      true,
-      true,
-    )
   })
 
   it('renders V2 create and details pages for a targeted non-admin', () => {

--- a/frontend/apps/webv2/app/immersion/log-feature-flag-pages.test.tsx
+++ b/frontend/apps/webv2/app/immersion/log-feature-flag-pages.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+Reflect.set(globalThis, 'React', React)
+
+const {
+  featureDecision,
+  useLatchedFeatureFlag,
+  useLog,
+  useLogConfigurationOptions,
+  useOngoingContestRegistrations,
+  useUserRole,
+} = vi.hoisted(() => ({
+  featureDecision: { enabled: false },
+  useLatchedFeatureFlag: vi.fn(),
+  useLog: vi.fn(),
+  useLogConfigurationOptions: vi.fn(),
+  useOngoingContestRegistrations: vi.fn(),
+  useUserRole: vi.fn(),
+}))
+
+vi.mock('@app/feature-flags/client', () => ({ useLatchedFeatureFlag }))
+
+vi.mock('@app/common/session', () => ({
+  useSession: () => [{ identity: { id: 'user-id' } }],
+  useSessionOrRedirect: vi.fn(),
+  useUserRole,
+}))
+
+vi.mock('@app/common/hooks', () => ({
+  useCurrentDateTime: () => ({ diff: () => ({ as: () => 1 }) }),
+}))
+
+vi.mock('@app/common/format', () => ({
+  colorForActivity: () => 'lime',
+  formatArray: () => null,
+  formatDuration: () => '1 minute',
+  formatScore: (value: number) => value.toString(),
+  formatUnit: () => 'pages',
+  hasTrackedAmount: () => true,
+}))
+
+vi.mock('@app/immersion/api', () => ({
+  useDeleteLog: () => ({ mutate: vi.fn() }),
+  useLog,
+  useLogConfigurationOptions,
+  useOngoingContestRegistrations,
+}))
+
+vi.mock('@app/immersion/NewLogForm/Form', () => ({
+  LogForm: () => <div>legacy create form</div>,
+}))
+
+vi.mock('@app/immersion/NewLogFormV2/Form', () => ({
+  LogFormV2: () => <div>v2 create form</div>,
+}))
+
+vi.mock('@app/immersion/LogDetailsV2', () => ({
+  LogDetailsV2: () => <div>v2 log details</div>,
+}))
+
+vi.mock('@app/immersion/EditLogForm/Form', () => ({
+  EditLogForm: () => <div>v2 edit form</div>,
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    query: { amount: '12', id: 'log-id' },
+    replace: vi.fn(),
+  }),
+}))
+
+vi.mock('next/head', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: {} }),
+}))
+
+vi.mock('@heroicons/react/20/solid', () => ({
+  HomeIcon: () => null,
+  TrashIcon: () => null,
+}))
+
+vi.mock('@heroicons/react/24/outline', () => ({
+  XMarkIcon: () => null,
+}))
+
+vi.mock('ui', () => ({
+  Breadcrumb: () => null,
+  ButtonGroup: () => null,
+  Loading: () => <div>loading</div>,
+  Modal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import LogDetailsPage from '../../pages/logs/[id]'
+import EditLogPage from '../../pages/logs/[id]/edit'
+import NewLogPage from '../../pages/logs/new'
+
+const optionsResult = {
+  data: {},
+  isError: false,
+  isLoading: false,
+  isSuccess: true,
+}
+
+const registrationsResult = {
+  data: { registrations: [] },
+  isError: false,
+  isLoading: false,
+  isSuccess: true,
+}
+
+const log = {
+  activity: { id: 1, name: 'Reading' },
+  amount: 12,
+  created_at: '2026-08-31T00:00:00Z',
+  deleted: false,
+  description: undefined,
+  id: 'log-id',
+  language: { name: 'Japanese' },
+  modifier: 1,
+  registrations: [],
+  score: 12,
+  tags: [],
+  unit_name: 'page',
+  user_display_name: 'Reader',
+  user_id: 'user-id',
+}
+
+describe('release-log-entry-v2 pages', () => {
+  beforeEach(() => {
+    useLatchedFeatureFlag.mockReset()
+    useLog.mockReset()
+    useLogConfigurationOptions.mockReset()
+    useOngoingContestRegistrations.mockReset()
+    useUserRole.mockReset()
+
+    featureDecision.enabled = false
+    useLatchedFeatureFlag.mockImplementation(
+      (_flag: string, _ready: boolean, enabledOverride = false) =>
+        enabledOverride || featureDecision.enabled,
+    )
+    useUserRole.mockReturnValue('user')
+    useLogConfigurationOptions.mockReturnValue(optionsResult)
+    useOngoingContestRegistrations.mockReturnValue(registrationsResult)
+    useLog.mockReturnValue({
+      data: log,
+      isError: false,
+      isIdle: false,
+      isLoading: false,
+    })
+  })
+
+  it('renders legacy create and details pages for an ordinary user when disabled', () => {
+    expect(renderToStaticMarkup(<NewLogPage />)).toContain('legacy create form')
+    expect(useOngoingContestRegistrations).toHaveBeenCalledWith({
+      enabled: true,
+    })
+
+    const details = renderToStaticMarkup(<LogDetailsPage />)
+    expect(details).toContain('Log details')
+    expect(details).not.toContain('v2 log details')
+  })
+
+  it('preserves the existing V2 journey for admins when the flag is disabled', () => {
+    useUserRole.mockReturnValue('admin')
+
+    expect(renderToStaticMarkup(<NewLogPage />)).toContain('v2 create form')
+    expect(renderToStaticMarkup(<LogDetailsPage />)).toContain('v2 log details')
+    expect(renderToStaticMarkup(<EditLogPage />)).toContain('v2 edit form')
+
+    expect(useLatchedFeatureFlag).toHaveBeenCalledWith(
+      'release-log-entry-v2',
+      true,
+      true,
+    )
+  })
+
+  it('renders V2 create and details pages for a targeted non-admin', () => {
+    featureDecision.enabled = true
+
+    expect(renderToStaticMarkup(<NewLogPage />)).toContain('v2 create form')
+    expect(useOngoingContestRegistrations).toHaveBeenCalledWith({
+      enabled: false,
+    })
+    expect(renderToStaticMarkup(<LogDetailsPage />)).toContain('v2 log details')
+  })
+
+  it('gates editing for ordinary users on the feature decision', () => {
+    expect(renderToStaticMarkup(<EditLogPage />)).toContain(
+      'This feature is not yet available.',
+    )
+
+    featureDecision.enabled = true
+    expect(renderToStaticMarkup(<EditLogPage />)).toContain('v2 edit form')
+  })
+})

--- a/frontend/apps/webv2/deployments/frontend-webv2.yaml
+++ b/frontend/apps/webv2/deployments/frontend-webv2.yaml
@@ -32,6 +32,8 @@ spec:
           value: {{TADOKU_APP_URL}}
         - name: NEXT_PUBLIC_API_ENDPOINT
           value: {{TADOKU_APP_URL}}/api/internal
+        - name: NEXT_SERVER_API_ENDPOINT
+          value: http://oathkeeper-proxy.default:4455/api/internal
         - name: NEXT_PUBLIC_COOKIE_DOMAIN
           value: .{{TADOKU_COOKIE_DOMAIN}}
         - name: NEXT_PUBLIC_COOKIE_SECURE

--- a/frontend/apps/webv2/next.config.js
+++ b/frontend/apps/webv2/next.config.js
@@ -3,6 +3,12 @@ const nextConfig = {
   output: 'standalone',
   reactStrictMode: true,
   swcMinify: true,
+  serverRuntimeConfig: {
+    apiEndpoint:
+      process.env.NEXT_SERVER_API_ENDPOINT ??
+      process.env.NEXT_PUBLIC_API_ENDPOINT ??
+      'https://tadoku.app/api/internal',
+  },
   publicRuntimeConfig: {
     // TODO: Figure out why this isn't getting passed to the client despite being opted-out from automatic static optimization
     kratosPublicEndpoint:

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -20,12 +20,18 @@ import { useState } from 'react'
 import { Breadcrumb, ButtonGroup, Loading, Modal } from 'ui'
 import { toast } from 'react-toastify'
 import Head from 'next/head'
+import { useLatchedFeatureFlag } from '@app/feature-flags/client'
 
 const Page = () => {
   const router = useRouter()
   const id = router.query['id']?.toString() ?? ''
   const log = useLog(id)
   const role = useUserRole()
+  const useV2 = useLatchedFeatureFlag(
+    'release-log-entry-v2',
+    role !== undefined,
+    role === 'admin',
+  )
 
   if (log.isLoading || log.isIdle) {
     return <Loading />
@@ -60,11 +66,11 @@ const Page = () => {
     )
   }
 
-  if (role === undefined) {
+  if (role === undefined || useV2 === undefined) {
     return <Loading />
   }
 
-  if (role === 'admin') {
+  if (useV2) {
     return (
       <>
         <Head>

--- a/frontend/apps/webv2/pages/logs/[id].tsx
+++ b/frontend/apps/webv2/pages/logs/[id].tsx
@@ -8,7 +8,7 @@ import {
 } from '@app/common/format'
 import { useCurrentDateTime } from '@app/common/hooks'
 import { routes } from '@app/common/routes'
-import { useSession, useUserRole } from '@app/common/session'
+import { useSession } from '@app/common/session'
 import { Log, useDeleteLog, useLog } from '@app/immersion/api'
 import { LogDetailsV2 } from '@app/immersion/LogDetailsV2'
 import { HomeIcon, TrashIcon } from '@heroicons/react/20/solid'
@@ -26,12 +26,7 @@ const Page = () => {
   const router = useRouter()
   const id = router.query['id']?.toString() ?? ''
   const log = useLog(id)
-  const role = useUserRole()
-  const useV2 = useLatchedFeatureFlag(
-    'release-log-entry-v2',
-    role !== undefined,
-    role === 'admin',
-  )
+  const useV2 = useLatchedFeatureFlag('release-log-entry-v2')
 
   if (log.isLoading || log.isIdle) {
     return <Loading />
@@ -64,10 +59,6 @@ const Page = () => {
         Could not load page, please try again later.
       </span>
     )
-  }
-
-  if (role === undefined || useV2 === undefined) {
-    return <Loading />
   }
 
   if (useV2) {

--- a/frontend/apps/webv2/pages/logs/[id]/edit.tsx
+++ b/frontend/apps/webv2/pages/logs/[id]/edit.tsx
@@ -6,21 +6,33 @@ import { EditLogForm } from '@app/immersion/EditLogForm/Form'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import { useSessionOrRedirect, useUserRole } from '@app/common/session'
+import { useLatchedFeatureFlag } from '@app/feature-flags/client'
 
 const Page = () => {
   const router = useRouter()
   const id = router.query['id']?.toString() ?? ''
   const role = useUserRole()
+  const useV2 = useLatchedFeatureFlag(
+    'release-log-entry-v2',
+    role !== undefined,
+    role === 'admin',
+  )
   const log = useLog(id, { enabled: !!id })
   const options = useLogConfigurationOptions()
 
   useSessionOrRedirect()
 
-  if (role === undefined || log.isLoading || log.isIdle || options.isLoading) {
+  if (
+    role === undefined ||
+    useV2 === undefined ||
+    log.isLoading ||
+    log.isIdle ||
+    options.isLoading
+  ) {
     return <Loading />
   }
 
-  if (role !== 'admin') {
+  if (!useV2) {
     return (
       <span className="flash error">This feature is not yet available.</span>
     )

--- a/frontend/apps/webv2/pages/logs/[id]/edit.tsx
+++ b/frontend/apps/webv2/pages/logs/[id]/edit.tsx
@@ -5,26 +5,19 @@ import { routes } from '@app/common/routes'
 import { EditLogForm } from '@app/immersion/EditLogForm/Form'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { useSessionOrRedirect, useUserRole } from '@app/common/session'
+import { useSessionOrRedirect } from '@app/common/session'
 import { useLatchedFeatureFlag } from '@app/feature-flags/client'
 
 const Page = () => {
   const router = useRouter()
   const id = router.query['id']?.toString() ?? ''
-  const role = useUserRole()
-  const useV2 = useLatchedFeatureFlag(
-    'release-log-entry-v2',
-    role !== undefined,
-    role === 'admin',
-  )
+  const useV2 = useLatchedFeatureFlag('release-log-entry-v2')
   const log = useLog(id, { enabled: !!id })
   const options = useLogConfigurationOptions()
 
   useSessionOrRedirect()
 
   if (
-    role === undefined ||
-    useV2 === undefined ||
     log.isLoading ||
     log.isIdle ||
     options.isLoading

--- a/frontend/apps/webv2/pages/logs/new.tsx
+++ b/frontend/apps/webv2/pages/logs/new.tsx
@@ -12,14 +12,20 @@ import { useRouter } from 'next/router'
 import { getQueryStringIntParameter } from '@app/common/router'
 import Head from 'next/head'
 import { useSessionOrRedirect, useUserRole } from '@app/common/session'
+import { useLatchedFeatureFlag } from '@app/feature-flags/client'
 
 interface Props {}
 
 const Page: NextPage<Props> = () => {
   const role = useUserRole()
+  const useV2 = useLatchedFeatureFlag(
+    'release-log-entry-v2',
+    role !== undefined,
+    role === 'admin',
+  )
   const options = useLogConfigurationOptions()
   const registrations = useOngoingContestRegistrations({
-    enabled: role !== 'admin',
+    enabled: useV2 === false,
   })
 
   useSessionOrRedirect()
@@ -27,7 +33,7 @@ const Page: NextPage<Props> = () => {
   const router = useRouter()
   const amount = getQueryStringIntParameter(router.query['amount'], 0)
 
-  if (role === undefined) {
+  if (role === undefined || useV2 === undefined) {
     return <Loading />
   }
 
@@ -45,7 +51,7 @@ const Page: NextPage<Props> = () => {
         />
       </div>
       <h1 className="title mb-4">New log</h1>
-      {role === 'admin' ? (
+      {useV2 ? (
         <>
           {options.isLoading ? <Loading /> : null}
           {options.isError ? (

--- a/frontend/apps/webv2/pages/logs/new.tsx
+++ b/frontend/apps/webv2/pages/logs/new.tsx
@@ -11,18 +11,13 @@ import { LogFormV2 } from '@app/immersion/NewLogFormV2/Form'
 import { useRouter } from 'next/router'
 import { getQueryStringIntParameter } from '@app/common/router'
 import Head from 'next/head'
-import { useSessionOrRedirect, useUserRole } from '@app/common/session'
+import { useSessionOrRedirect } from '@app/common/session'
 import { useLatchedFeatureFlag } from '@app/feature-flags/client'
 
 interface Props {}
 
 const Page: NextPage<Props> = () => {
-  const role = useUserRole()
-  const useV2 = useLatchedFeatureFlag(
-    'release-log-entry-v2',
-    role !== undefined,
-    role === 'admin',
-  )
+  const useV2 = useLatchedFeatureFlag('release-log-entry-v2')
   const options = useLogConfigurationOptions()
   const registrations = useOngoingContestRegistrations({
     enabled: useV2 === false,
@@ -32,10 +27,6 @@ const Page: NextPage<Props> = () => {
 
   const router = useRouter()
   const amount = getQueryStringIntParameter(router.query['amount'], 0)
-
-  if (role === undefined || useV2 === undefined) {
-    return <Loading />
-  }
 
   return (
     <>

--- a/infra/dev/ory/access_rules.yaml
+++ b/infra/dev/ory/access_rules.yaml
@@ -40,6 +40,22 @@
   mutators:
     - handler: id_token
 
+- id: "tadoku:immersion:feature-flags:internal"
+  upstream:
+    preserve_host: true
+    url: "http://immersion-api.tdk-immersion-api:80"
+    strip_path: /api/internal/immersion/
+  match:
+    url: "http://oathkeeper-proxy.default:4455/api/internal/immersion/feature-flags"
+    methods:
+      - GET
+  authenticators:
+    - handler: cookie_session
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+
 - id: "tadoku:authz:api"
   upstream:
     preserve_host: true


### PR DESCRIPTION
## Summary

- use the Flipt decision as the sole source of access to the existing V2 create, details, and edit log journey, including for admins
- keep the legacy journey as the safe default and latch the selected journey for each mounted page so refreshes cannot discard in-progress form input
- bootstrap SSR decisions through a server-only internal Oathkeeper endpoint, while browser refreshes continue using the public endpoint
- keep backend behavior unchanged because V1 and V2 already use compatible authenticated endpoints and the scoring-engine switch is an independent concern

## Safety

- missing, failed, or disabled decisions resolve to the legacy experience
- no frontend role or admin bypass can diverge from Flipt targeting
- no Flipt SDK, client token, or sensitive configuration is added to the browser
- the dev Flipt seed remains disabled by default; local live-test targeting was restored to admin-only

## Verification

- `pnpm --filter webv2 test` — 31 tests passed
- `pnpm --filter webv2 exec tsc --noEmit`
- `pnpm --filter webv2 lint`
- `pnpm build`
- standard root `tilt up` healthy for webv2, Oathkeeper, Flipt, and immersion-api
- live reader decision verified through both API and SSR with targeting enabled, then verified legacy SSR after targeting was removed
