### PR TITLE
Add account deletion eligibility guard

### DIFF
--- a/services/immersion-api/domain/BUILD.bazel
+++ b/services/immersion-api/domain/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "domain",
     srcs = [
+        "accountdeletioneligibility.go",
         "accountdeletionlock.go",
         "accountdeletionscrub.go",
         "activities.go",
@@ -70,6 +71,7 @@ go_library(
 go_test(
     name = "domain_test",
     srcs = [
+        "accountdeletioneligibility_test.go",
         "accountdeletionlock_test.go",
         "accountdeletionscrub_test.go",
         "activities_test.go",

--- a/services/immersion-api/domain/accountdeletioneligibility.go
+++ b/services/immersion-api/domain/accountdeletioneligibility.go
@@ -1,0 +1,62 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	commondomain "github.com/tadoku/tadoku/services/common/domain"
+)
+
+type AccountDeletionEligibilityRepository interface {
+	FindRunningOwnedContestAvailableAfter(context.Context, uuid.UUID, time.Time) (*time.Time, error)
+}
+
+type AccountDeletionEligibilityRequest struct {
+	UserID uuid.UUID
+
+	checkedAt time.Time
+}
+
+func (r *AccountDeletionEligibilityRequest) CheckedAt() time.Time {
+	return r.checkedAt
+}
+
+type AccountDeletionEligibilityResult struct {
+	AvailableAfter *time.Time
+}
+
+func (r *AccountDeletionEligibilityResult) Eligible() bool {
+	return r.AvailableAfter == nil
+}
+
+type AccountDeletionEligibility struct {
+	repo  AccountDeletionEligibilityRepository
+	clock commondomain.Clock
+}
+
+func NewAccountDeletionEligibility(repo AccountDeletionEligibilityRepository, clock commondomain.Clock) *AccountDeletionEligibility {
+	return &AccountDeletionEligibility{repo: repo, clock: clock}
+}
+
+func (s *AccountDeletionEligibility) Execute(ctx context.Context, req *AccountDeletionEligibilityRequest) (*AccountDeletionEligibilityResult, error) {
+	service := commondomain.ParseServiceIdentity(ctx)
+	if service == nil {
+		return nil, ErrUnauthorized
+	}
+	if service.Name != accountDeletionCaller {
+		return nil, ErrForbidden
+	}
+	if req == nil || req.UserID == uuid.Nil {
+		return nil, ErrRequestInvalid
+	}
+
+	req.checkedAt = s.clock.Now().UTC()
+	availableAfter, err := s.repo.FindRunningOwnedContestAvailableAfter(ctx, req.UserID, req.checkedAt)
+	if err != nil {
+		return nil, fmt.Errorf("could not check account deletion eligibility: %w", err)
+	}
+
+	return &AccountDeletionEligibilityResult{AvailableAfter: availableAfter}, nil
+}

--- a/services/immersion-api/domain/accountdeletioneligibility_test.go
+++ b/services/immersion-api/domain/accountdeletioneligibility_test.go
@@ -1,0 +1,84 @@
+package domain_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commondomain "github.com/tadoku/tadoku/services/common/domain"
+	"github.com/tadoku/tadoku/services/immersion-api/domain"
+)
+
+type accountDeletionEligibilityRepositoryMock struct {
+	userID         uuid.UUID
+	checkedAt      time.Time
+	availableAfter *time.Time
+	err            error
+}
+
+func (m *accountDeletionEligibilityRepositoryMock) FindRunningOwnedContestAvailableAfter(_ context.Context, userID uuid.UUID, checkedAt time.Time) (*time.Time, error) {
+	m.userID = userID
+	m.checkedAt = checkedAt
+	return m.availableAfter, m.err
+}
+
+func TestAccountDeletionEligibilityReturnsRepositoryResult(t *testing.T) {
+	clockTime := time.Date(2026, 9, 1, 14, 0, 0, 0, time.FixedZone("CEST", 2*60*60))
+	availableAfter := time.Date(2026, 9, 3, 0, 0, 0, 0, time.UTC)
+	repo := &accountDeletionEligibilityRepositoryMock{availableAfter: &availableAfter}
+	service := domain.NewAccountDeletionEligibility(repo, commondomain.NewMockClock(clockTime))
+	userID := uuid.New()
+	req := &domain.AccountDeletionEligibilityRequest{UserID: userID}
+
+	result, err := service.Execute(serviceContext("profile-api"), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Eligible())
+	assert.Equal(t, availableAfter, *result.AvailableAfter)
+	assert.Equal(t, userID, repo.userID)
+	assert.Equal(t, clockTime.UTC(), repo.checkedAt)
+	assert.Equal(t, clockTime.UTC(), req.CheckedAt())
+}
+
+func TestAccountDeletionEligibilityReturnsEligibleWithoutBlocker(t *testing.T) {
+	service := domain.NewAccountDeletionEligibility(&accountDeletionEligibilityRepositoryMock{}, commondomain.NewMockClock(time.Now()))
+	result, err := service.Execute(serviceContext("profile-api"), &domain.AccountDeletionEligibilityRequest{UserID: uuid.New()})
+	require.NoError(t, err)
+	assert.True(t, result.Eligible())
+}
+
+func TestAccountDeletionEligibilityValidatesCallerAndRequest(t *testing.T) {
+	valid := &domain.AccountDeletionEligibilityRequest{UserID: uuid.New()}
+	for name, tc := range map[string]struct {
+		ctx context.Context
+		req *domain.AccountDeletionEligibilityRequest
+		err error
+	}{
+		"user caller":   {context.Background(), valid, domain.ErrUnauthorized},
+		"wrong service": {serviceContext("content-api"), valid, domain.ErrForbidden},
+		"nil request":   {serviceContext("profile-api"), nil, domain.ErrRequestInvalid},
+		"missing user":  {serviceContext("profile-api"), &domain.AccountDeletionEligibilityRequest{}, domain.ErrRequestInvalid},
+	} {
+		t.Run(name, func(t *testing.T) {
+			service := domain.NewAccountDeletionEligibility(&accountDeletionEligibilityRepositoryMock{}, commondomain.NewMockClock(time.Now()))
+			_, err := service.Execute(tc.ctx, tc.req)
+			assert.ErrorIs(t, err, tc.err)
+		})
+	}
+}
+
+func TestAccountDeletionEligibilityWrapsRepositoryError(t *testing.T) {
+	repoErr := errors.New("database unavailable")
+	service := domain.NewAccountDeletionEligibility(
+		&accountDeletionEligibilityRepositoryMock{err: repoErr},
+		commondomain.NewMockClock(time.Now()),
+	)
+
+	_, err := service.Execute(serviceContext("profile-api"), &domain.AccountDeletionEligibilityRequest{UserID: uuid.New()})
+	assert.ErrorIs(t, err, repoErr)
+}

--- a/services/immersion-api/domain/accountdeletionlock.go
+++ b/services/immersion-api/domain/accountdeletionlock.go
@@ -47,7 +47,7 @@ func (s *AccountDeletionLock) Execute(ctx context.Context, req *AccountDeletionL
 		return ErrRequestInvalid
 	}
 
-	req.lockedAt = s.clock.Now()
+	req.lockedAt = s.clock.Now().UTC()
 	if err := s.repo.LockAccountForDeletion(ctx, req); err != nil {
 		return fmt.Errorf("could not lock account for deletion: %w", err)
 	}

--- a/services/immersion-api/http/rest/openapi/internal-api.yaml
+++ b/services/immersion-api/http/rest/openapi/internal-api.yaml
@@ -9,6 +9,34 @@ info:
 servers:
   - url: http://immersion-api:8080/
 paths:
+  /internal/v1/account-deletion-eligibility:
+    post:
+      summary: Checks whether an account owns a running contest that blocks deletion
+      operationId: internalAccountDeletionEligibility
+      tags: [internal]
+      security:
+        - serviceAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountDeletionEligibilityRequest'
+      responses:
+        '204':
+          description: account is currently eligible for deletion
+        '400':
+          description: invalid request
+        '401':
+          description: caller is not a service identity
+        '403':
+          description: caller is not profile-api
+        '409':
+          description: account owns at least one running contest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountDeletionEligibilityConflict'
   /internal/v1/account-deletion-scrubs:
     post:
       summary: Idempotently anonymizes and removes immersion data for a locked account
@@ -55,8 +83,31 @@ paths:
           description: caller is not a service identity
         '403':
           description: caller is not profile-api
+        '409':
+          description: account owns a running contest
 components:
   schemas:
+    AccountDeletionEligibilityRequest:
+      type: object
+      required:
+        - user_id
+      properties:
+        user_id:
+          type: string
+          format: uuid
+    AccountDeletionEligibilityConflict:
+      type: object
+      required:
+        - error
+        - available_after
+      properties:
+        error:
+          type: string
+          enum:
+            - running_contest_owned
+        available_after:
+          type: string
+          format: date-time
     AccountDeletionScrubRequest:
       type: object
       required:

--- a/services/immersion-api/http/rest/openapi/internalapi/api.gen.go
+++ b/services/immersion-api/http/rest/openapi/internalapi/api.gen.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/labstack/echo/v4"
@@ -20,6 +21,25 @@ import (
 const (
 	ServiceAuthScopes = "serviceAuth.Scopes"
 )
+
+// Defines values for AccountDeletionEligibilityConflictError.
+const (
+	RunningContestOwned AccountDeletionEligibilityConflictError = "running_contest_owned"
+)
+
+// AccountDeletionEligibilityConflict defines model for AccountDeletionEligibilityConflict.
+type AccountDeletionEligibilityConflict struct {
+	AvailableAfter time.Time                               `json:"available_after"`
+	Error          AccountDeletionEligibilityConflictError `json:"error"`
+}
+
+// AccountDeletionEligibilityConflictError defines model for AccountDeletionEligibilityConflict.Error.
+type AccountDeletionEligibilityConflictError string
+
+// AccountDeletionEligibilityRequest defines model for AccountDeletionEligibilityRequest.
+type AccountDeletionEligibilityRequest struct {
+	UserId openapi_types.UUID `json:"user_id"`
+}
 
 // AccountDeletionLockRequest defines model for AccountDeletionLockRequest.
 type AccountDeletionLockRequest struct {
@@ -32,6 +52,9 @@ type AccountDeletionScrubRequest struct {
 	RequestId openapi_types.UUID `json:"request_id"`
 	UserId    openapi_types.UUID `json:"user_id"`
 }
+
+// InternalAccountDeletionEligibilityJSONRequestBody defines body for InternalAccountDeletionEligibility for application/json ContentType.
+type InternalAccountDeletionEligibilityJSONRequestBody = AccountDeletionEligibilityRequest
 
 // InternalAccountDeletionLockJSONRequestBody defines body for InternalAccountDeletionLock for application/json ContentType.
 type InternalAccountDeletionLockJSONRequestBody = AccountDeletionLockRequest
@@ -112,6 +135,11 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// InternalAccountDeletionEligibility request with any body
+	InternalAccountDeletionEligibilityWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	InternalAccountDeletionEligibility(ctx context.Context, body InternalAccountDeletionEligibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// InternalAccountDeletionLock request with any body
 	InternalAccountDeletionLockWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -121,6 +149,30 @@ type ClientInterface interface {
 	InternalAccountDeletionScrubWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	InternalAccountDeletionScrub(ctx context.Context, body InternalAccountDeletionScrubJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) InternalAccountDeletionEligibilityWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInternalAccountDeletionEligibilityRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InternalAccountDeletionEligibility(ctx context.Context, body InternalAccountDeletionEligibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInternalAccountDeletionEligibilityRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) InternalAccountDeletionLockWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -169,6 +221,46 @@ func (c *Client) InternalAccountDeletionScrub(ctx context.Context, body Internal
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewInternalAccountDeletionEligibilityRequest calls the generic InternalAccountDeletionEligibility builder with application/json body
+func NewInternalAccountDeletionEligibilityRequest(server string, body InternalAccountDeletionEligibilityJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewInternalAccountDeletionEligibilityRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewInternalAccountDeletionEligibilityRequestWithBody generates requests for InternalAccountDeletionEligibility with any type of body
+func NewInternalAccountDeletionEligibilityRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/internal/v1/account-deletion-eligibility")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
 }
 
 // NewInternalAccountDeletionLockRequest calls the generic InternalAccountDeletionLock builder with application/json body
@@ -294,6 +386,11 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// InternalAccountDeletionEligibility request with any body
+	InternalAccountDeletionEligibilityWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InternalAccountDeletionEligibilityResponse, error)
+
+	InternalAccountDeletionEligibilityWithResponse(ctx context.Context, body InternalAccountDeletionEligibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*InternalAccountDeletionEligibilityResponse, error)
+
 	// InternalAccountDeletionLock request with any body
 	InternalAccountDeletionLockWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InternalAccountDeletionLockResponse, error)
 
@@ -303,6 +400,28 @@ type ClientWithResponsesInterface interface {
 	InternalAccountDeletionScrubWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InternalAccountDeletionScrubResponse, error)
 
 	InternalAccountDeletionScrubWithResponse(ctx context.Context, body InternalAccountDeletionScrubJSONRequestBody, reqEditors ...RequestEditorFn) (*InternalAccountDeletionScrubResponse, error)
+}
+
+type InternalAccountDeletionEligibilityResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON409      *AccountDeletionEligibilityConflict
+}
+
+// Status returns HTTPResponse.Status
+func (r InternalAccountDeletionEligibilityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InternalAccountDeletionEligibilityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type InternalAccountDeletionLockResponse struct {
@@ -347,6 +466,23 @@ func (r InternalAccountDeletionScrubResponse) StatusCode() int {
 	return 0
 }
 
+// InternalAccountDeletionEligibilityWithBodyWithResponse request with arbitrary body returning *InternalAccountDeletionEligibilityResponse
+func (c *ClientWithResponses) InternalAccountDeletionEligibilityWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InternalAccountDeletionEligibilityResponse, error) {
+	rsp, err := c.InternalAccountDeletionEligibilityWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInternalAccountDeletionEligibilityResponse(rsp)
+}
+
+func (c *ClientWithResponses) InternalAccountDeletionEligibilityWithResponse(ctx context.Context, body InternalAccountDeletionEligibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*InternalAccountDeletionEligibilityResponse, error) {
+	rsp, err := c.InternalAccountDeletionEligibility(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInternalAccountDeletionEligibilityResponse(rsp)
+}
+
 // InternalAccountDeletionLockWithBodyWithResponse request with arbitrary body returning *InternalAccountDeletionLockResponse
 func (c *ClientWithResponses) InternalAccountDeletionLockWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InternalAccountDeletionLockResponse, error) {
 	rsp, err := c.InternalAccountDeletionLockWithBody(ctx, contentType, body, reqEditors...)
@@ -379,6 +515,32 @@ func (c *ClientWithResponses) InternalAccountDeletionScrubWithResponse(ctx conte
 		return nil, err
 	}
 	return ParseInternalAccountDeletionScrubResponse(rsp)
+}
+
+// ParseInternalAccountDeletionEligibilityResponse parses an HTTP response from a InternalAccountDeletionEligibilityWithResponse call
+func ParseInternalAccountDeletionEligibilityResponse(rsp *http.Response) (*InternalAccountDeletionEligibilityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InternalAccountDeletionEligibilityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest AccountDeletionEligibilityConflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseInternalAccountDeletionLockResponse parses an HTTP response from a InternalAccountDeletionLockWithResponse call
@@ -415,6 +577,9 @@ func ParseInternalAccountDeletionScrubResponse(rsp *http.Response) (*InternalAcc
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Checks whether an account owns a running contest that blocks deletion
+	// (POST /internal/v1/account-deletion-eligibility)
+	InternalAccountDeletionEligibility(ctx echo.Context) error
 	// Idempotently prevents further mutations for an account
 	// (POST /internal/v1/account-deletion-locks)
 	InternalAccountDeletionLock(ctx echo.Context) error
@@ -426,6 +591,17 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts echo contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler ServerInterface
+}
+
+// InternalAccountDeletionEligibility converts echo context to params.
+func (w *ServerInterfaceWrapper) InternalAccountDeletionEligibility(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(ServiceAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.InternalAccountDeletionEligibility(ctx)
+	return err
 }
 
 // InternalAccountDeletionLock converts echo context to params.
@@ -478,6 +654,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
+	router.POST(baseURL+"/internal/v1/account-deletion-eligibility", wrapper.InternalAccountDeletionEligibility)
 	router.POST(baseURL+"/internal/v1/account-deletion-locks", wrapper.InternalAccountDeletionLock)
 	router.POST(baseURL+"/internal/v1/account-deletion-scrubs", wrapper.InternalAccountDeletionScrub)
 

--- a/services/immersion-api/http/rest/server_internal.go
+++ b/services/immersion-api/http/rest/server_internal.go
@@ -17,16 +17,52 @@ type accountDeletionScrubber interface {
 	Execute(context.Context, *domain.AccountDeletionScrubRequest) error
 }
 
-type InternalServer struct {
-	accountDeletionLock  accountDeletionLocker
-	accountDeletionScrub accountDeletionScrubber
+type accountDeletionEligibilityChecker interface {
+	Execute(context.Context, *domain.AccountDeletionEligibilityRequest) (*domain.AccountDeletionEligibilityResult, error)
 }
 
-func NewInternalServer(accountDeletionLock accountDeletionLocker, accountDeletionScrub accountDeletionScrubber) *InternalServer {
+type InternalServer struct {
+	accountDeletionLock        accountDeletionLocker
+	accountDeletionScrub       accountDeletionScrubber
+	accountDeletionEligibility accountDeletionEligibilityChecker
+}
+
+func NewInternalServer(
+	accountDeletionLock accountDeletionLocker,
+	accountDeletionScrub accountDeletionScrubber,
+	accountDeletionEligibility accountDeletionEligibilityChecker,
+) *InternalServer {
 	return &InternalServer{
-		accountDeletionLock:  accountDeletionLock,
-		accountDeletionScrub: accountDeletionScrub,
+		accountDeletionLock:        accountDeletionLock,
+		accountDeletionScrub:       accountDeletionScrub,
+		accountDeletionEligibility: accountDeletionEligibility,
 	}
+}
+
+func (s *InternalServer) InternalAccountDeletionEligibility(ctx echo.Context) error {
+	var body internalapi.InternalAccountDeletionEligibilityJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return ctx.NoContent(http.StatusBadRequest)
+	}
+
+	result, err := s.accountDeletionEligibility.Execute(ctx.Request().Context(), &domain.AccountDeletionEligibilityRequest{
+		UserID: body.UserId,
+	})
+	if err != nil {
+		if handled, responseErr := handleCommonErrors(ctx, err); handled {
+			return responseErr
+		}
+		ctx.Echo().Logger.Error("could not check account deletion eligibility: ", err)
+		return ctx.NoContent(http.StatusInternalServerError)
+	}
+	if !result.Eligible() {
+		return ctx.JSON(http.StatusConflict, internalapi.AccountDeletionEligibilityConflict{
+			Error:          internalapi.RunningContestOwned,
+			AvailableAfter: *result.AvailableAfter,
+		})
+	}
+
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *InternalServer) InternalAccountDeletionScrub(ctx echo.Context) error {

--- a/services/immersion-api/http/rest/server_internal_test.go
+++ b/services/immersion-api/http/rest/server_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -25,6 +26,20 @@ type accountDeletionScrubberMock struct {
 	err error
 }
 
+type accountDeletionEligibilityCheckerMock struct {
+	req    *domain.AccountDeletionEligibilityRequest
+	result *domain.AccountDeletionEligibilityResult
+	err    error
+}
+
+func (m *accountDeletionEligibilityCheckerMock) Execute(_ context.Context, req *domain.AccountDeletionEligibilityRequest) (*domain.AccountDeletionEligibilityResult, error) {
+	m.req = req
+	if m.result == nil {
+		m.result = &domain.AccountDeletionEligibilityResult{}
+	}
+	return m.result, m.err
+}
+
 func (m *accountDeletionScrubberMock) Execute(_ context.Context, req *domain.AccountDeletionScrubRequest) error {
 	m.req = req
 	return m.err
@@ -39,7 +54,7 @@ func TestInternalAccountDeletionLock(t *testing.T) {
 	userID := uuid.New()
 	requestID := uuid.New()
 	locker := &accountDeletionLockerMock{}
-	server := NewInternalServer(locker, &accountDeletionScrubberMock{})
+	server := NewInternalServer(locker, &accountDeletionScrubberMock{}, &accountDeletionEligibilityCheckerMock{})
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/internal/v1/account-deletion-locks", strings.NewReader(
 		`{"user_id":"`+userID.String()+`","request_id":"`+requestID.String()+`"}`,
@@ -61,12 +76,13 @@ func TestInternalAccountDeletionLockMapsDomainErrors(t *testing.T) {
 		err    error
 		status int
 	}{
-		"invalid":    {domain.ErrRequestInvalid, http.StatusBadRequest},
-		"forbidden":  {domain.ErrForbidden, http.StatusForbidden},
-		"unexpected": {errors.New("database unavailable"), http.StatusInternalServerError},
+		"invalid":         {domain.ErrRequestInvalid, http.StatusBadRequest},
+		"forbidden":       {domain.ErrForbidden, http.StatusForbidden},
+		"running contest": {domain.ErrRunningContestOwned, http.StatusConflict},
+		"unexpected":      {errors.New("database unavailable"), http.StatusInternalServerError},
 	} {
 		t.Run(name, func(t *testing.T) {
-			server := NewInternalServer(&accountDeletionLockerMock{err: tc.err}, &accountDeletionScrubberMock{})
+			server := NewInternalServer(&accountDeletionLockerMock{err: tc.err}, &accountDeletionScrubberMock{}, &accountDeletionEligibilityCheckerMock{})
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
 				`{"user_id":"`+uuid.NewString()+`","request_id":"`+uuid.NewString()+`"}`,
@@ -84,7 +100,7 @@ func TestInternalAccountDeletionScrub(t *testing.T) {
 	userID := uuid.New()
 	requestID := uuid.New()
 	scrubber := &accountDeletionScrubberMock{}
-	server := NewInternalServer(&accountDeletionLockerMock{}, scrubber)
+	server := NewInternalServer(&accountDeletionLockerMock{}, scrubber, &accountDeletionEligibilityCheckerMock{})
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/internal/v1/account-deletion-scrubs", strings.NewReader(
 		`{"user_id":"`+userID.String()+`","request_id":"`+requestID.String()+`"}`,
@@ -108,7 +124,7 @@ func TestInternalAccountDeletionScrubMapsConflicts(t *testing.T) {
 		"running contest": {domain.ErrRunningContestOwned, "running_contest_owned"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			server := NewInternalServer(&accountDeletionLockerMock{}, &accountDeletionScrubberMock{err: tc.err})
+			server := NewInternalServer(&accountDeletionLockerMock{}, &accountDeletionScrubberMock{err: tc.err}, &accountDeletionEligibilityCheckerMock{})
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
 				`{"user_id":"`+uuid.NewString()+`","request_id":"`+uuid.NewString()+`"}`,
@@ -119,6 +135,63 @@ func TestInternalAccountDeletionScrubMapsConflicts(t *testing.T) {
 			require.NoError(t, server.InternalAccountDeletionScrub(e.NewContext(req, recorder)))
 			assert.Equal(t, http.StatusConflict, recorder.Code)
 			assert.JSONEq(t, `{"error":"`+tc.code+`"}`, recorder.Body.String())
+		})
+	}
+}
+
+func TestInternalAccountDeletionEligibility(t *testing.T) {
+	userID := uuid.New()
+	checker := &accountDeletionEligibilityCheckerMock{}
+	server := NewInternalServer(&accountDeletionLockerMock{}, &accountDeletionScrubberMock{}, checker)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/account-deletion-eligibility", strings.NewReader(
+		`{"user_id":"`+userID.String()+`"}`,
+	))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	recorder := httptest.NewRecorder()
+
+	require.NoError(t, server.InternalAccountDeletionEligibility(e.NewContext(req, recorder)))
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	require.NotNil(t, checker.req)
+	assert.Equal(t, userID, checker.req.UserID)
+}
+
+func TestInternalAccountDeletionEligibilityReturnsRunningOwnerConflict(t *testing.T) {
+	availableAfter := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	checker := &accountDeletionEligibilityCheckerMock{result: &domain.AccountDeletionEligibilityResult{AvailableAfter: &availableAfter}}
+	server := NewInternalServer(&accountDeletionLockerMock{}, &accountDeletionScrubberMock{}, checker)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"user_id":"`+uuid.NewString()+`"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	recorder := httptest.NewRecorder()
+
+	require.NoError(t, server.InternalAccountDeletionEligibility(e.NewContext(req, recorder)))
+	assert.Equal(t, http.StatusConflict, recorder.Code)
+	assert.JSONEq(t, `{"error":"running_contest_owned","available_after":"2026-09-05T00:00:00Z"}`, recorder.Body.String())
+}
+
+func TestInternalAccountDeletionEligibilityMapsErrors(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err    error
+		status int
+	}{
+		"invalid":    {domain.ErrRequestInvalid, http.StatusBadRequest},
+		"forbidden":  {domain.ErrForbidden, http.StatusForbidden},
+		"unexpected": {errors.New("database unavailable"), http.StatusInternalServerError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := NewInternalServer(
+				&accountDeletionLockerMock{},
+				&accountDeletionScrubberMock{},
+				&accountDeletionEligibilityCheckerMock{err: tc.err},
+			)
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"user_id":"`+uuid.NewString()+`"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			recorder := httptest.NewRecorder()
+
+			require.NoError(t, server.InternalAccountDeletionEligibility(e.NewContext(req, recorder)))
+			assert.Equal(t, tc.status, recorder.Code)
 		})
 	}
 }

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -229,6 +229,7 @@ func main() {
 	scoringRuleSetManagement := immersiondomain.NewScoringRuleSetManagement(postgresRepository, clock)
 	accountDeletionLock := immersiondomain.NewAccountDeletionLock(postgresRepository, clock)
 	accountDeletionScrub := immersiondomain.NewAccountDeletionScrub(postgresRepository, clock)
+	accountDeletionEligibility := immersiondomain.NewAccountDeletionEligibility(postgresRepository, clock)
 
 	server := rest.NewServer(
 		contestConfigurationOptions,
@@ -270,7 +271,7 @@ func main() {
 	)
 
 	openapi.RegisterHandlersWithBaseURL(api, server, "")
-	internalServer := rest.NewInternalServer(accountDeletionLock, accountDeletionScrub)
+	internalServer := rest.NewInternalServer(accountDeletionLock, accountDeletionScrub, accountDeletionEligibility)
 	internal := api.Group("", tadokumiddleware.RequireServiceIdentity())
 	rest.RegisterInternalRoutes(internal, internalServer)
 

--- a/services/immersion-api/storage/postgres/account_deletion.sql.go
+++ b/services/immersion-api/storage/postgres/account_deletion.sql.go
@@ -121,6 +121,29 @@ func (q *Queries) DetachNonHistoricalLogsForAccount(ctx context.Context, arg Det
 	return err
 }
 
+const findRunningOwnedContestAvailableAfter = `-- name: FindRunningOwnedContestAvailableAfter :one
+select (contest_end + 1)::timestamp as available_after
+from contests
+where owner_user_id = $1
+  and deleted_at is null
+  and contest_start <= $2::timestamp::date
+  and (contest_end + 1)::timestamp > $2::timestamp
+order by contest_end desc
+limit 1
+`
+
+type FindRunningOwnedContestAvailableAfterParams struct {
+	UserID    uuid.UUID
+	CheckedAt time.Time
+}
+
+func (q *Queries) FindRunningOwnedContestAvailableAfter(ctx context.Context, arg FindRunningOwnedContestAvailableAfterParams) (time.Time, error) {
+	row := q.db.QueryRowContext(ctx, findRunningOwnedContestAvailableAfter, arg.UserID, arg.CheckedAt)
+	var available_after time.Time
+	err := row.Scan(&available_after)
+	return available_after, err
+}
+
 const freezeHistoricalLogsForAccount = `-- name: FreezeHistoricalLogsForAccount :exec
 update logs
 set
@@ -146,29 +169,6 @@ type FreezeHistoricalLogsForAccountParams struct {
 func (q *Queries) FreezeHistoricalLogsForAccount(ctx context.Context, arg FreezeHistoricalLogsForAccountParams) error {
 	_, err := q.db.ExecContext(ctx, freezeHistoricalLogsForAccount, arg.DeletedAt, arg.UserID)
 	return err
-}
-
-const hasRunningOwnedContest = `-- name: HasRunningOwnedContest :one
-select exists (
-  select 1
-  from contests
-  where owner_user_id = $1
-    and deleted_at is null
-    and contest_start <= $2::date
-    and (contest_end + 1)::timestamp > $2
-) as has_running_contest
-`
-
-type HasRunningOwnedContestParams struct {
-	UserID    uuid.UUID
-	DeletedAt time.Time
-}
-
-func (q *Queries) HasRunningOwnedContest(ctx context.Context, arg HasRunningOwnedContestParams) (bool, error) {
-	row := q.db.QueryRowContext(ctx, hasRunningOwnedContest, arg.UserID, arg.DeletedAt)
-	var has_running_contest bool
-	err := row.Scan(&has_running_contest)
-	return has_running_contest, err
 }
 
 const listNonHistoricalContestIDsForAccount = `-- name: ListNonHistoricalContestIDsForAccount :many

--- a/services/immersion-api/storage/postgres/queries/account_deletion.sql
+++ b/services/immersion-api/storage/postgres/queries/account_deletion.sql
@@ -4,15 +4,15 @@ from users
 where id = sqlc.arg('user_id')
 for update;
 
--- name: HasRunningOwnedContest :one
-select exists (
-  select 1
-  from contests
-  where owner_user_id = sqlc.arg('user_id')
-    and deleted_at is null
-    and contest_start <= sqlc.arg('deleted_at')::date
-    and (contest_end + 1)::timestamp > sqlc.arg('deleted_at')
-) as has_running_contest;
+-- name: FindRunningOwnedContestAvailableAfter :one
+select (contest_end + 1)::timestamp as available_after
+from contests
+where owner_user_id = sqlc.arg('user_id')
+  and deleted_at is null
+  and contest_start <= sqlc.arg('checked_at')::timestamp::date
+  and (contest_end + 1)::timestamp > sqlc.arg('checked_at')::timestamp
+order by contest_end desc
+limit 1;
 
 -- name: ListNonHistoricalContestIDsForAccount :many
 select distinct associated_contests.contest_id

--- a/services/immersion-api/storage/postgres/queries/users.sql
+++ b/services/immersion-api/storage/postgres/queries/users.sql
@@ -26,18 +26,19 @@ from users
 where id = sqlc.arg('id')
 for update;
 
--- name: LockAccountForDeletion :exec
+-- name: EnsureAccountDeletionTarget :exec
 insert into users (
   id,
-  display_name,
-  deletion_locked_at
+  display_name
 ) values (
   sqlc.arg('id'),
-  '',
-  sqlc.arg('locked_at')
-) on conflict (id) do
-update set
-  deletion_locked_at = coalesce(users.deletion_locked_at, excluded.deletion_locked_at);
+  ''
+) on conflict (id) do nothing;
+
+-- name: SetAccountDeletionLock :exec
+update users
+set deletion_locked_at = coalesce(deletion_locked_at, sqlc.arg('locked_at'))
+where id = sqlc.arg('id');
 
 -- name: FindUserDisplayNames :many
 select id, display_name from users where id = any(sqlc.arg('ids')::uuid[]);

--- a/services/immersion-api/storage/postgres/repository/BUILD.bazel
+++ b/services/immersion-api/storage/postgres/repository/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "repository",
     srcs = [
+        "accountdeletioneligibility.go",
         "accountdeletionlock.go",
         "accountdeletionscrub.go",
         "logmutation.go",
@@ -64,6 +65,7 @@ go_library(
 go_test(
     name = "repository_test",
     srcs = [
+        "accountdeletioneligibility_integration_test.go",
         "accountdeletionlock_integration_test.go",
         "accountdeletionscrub_integration_test.go",
         "logcreate_integration_test.go",

--- a/services/immersion-api/storage/postgres/repository/accountdeletioneligibility.go
+++ b/services/immersion-api/storage/postgres/repository/accountdeletioneligibility.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres"
+)
+
+func findRunningOwnedContestAvailableAfter(ctx context.Context, q *postgres.Queries, userID uuid.UUID, checkedAt time.Time) (*time.Time, error) {
+	availableAfter, err := q.FindRunningOwnedContestAvailableAfter(ctx, postgres.FindRunningOwnedContestAvailableAfterParams{
+		UserID:    userID,
+		CheckedAt: checkedAt,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	availableAfter = availableAfter.UTC()
+	return &availableAfter, nil
+}
+
+func (r *Repository) FindRunningOwnedContestAvailableAfter(ctx context.Context, userID uuid.UUID, checkedAt time.Time) (*time.Time, error) {
+	availableAfter, err := findRunningOwnedContestAvailableAfter(ctx, r.q, userID, checkedAt)
+	if err != nil {
+		return nil, fmt.Errorf("could not find running owned contest: %w", err)
+	}
+	return availableAfter, nil
+}

--- a/services/immersion-api/storage/postgres/repository/accountdeletioneligibility_integration_test.go
+++ b/services/immersion-api/storage/postgres/repository/accountdeletioneligibility_integration_test.go
@@ -1,0 +1,89 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tadoku/tadoku/services/immersion-api/domain"
+	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres/postgrestest"
+)
+
+func TestAccountDeletionEligibilityUsesLatestRunningContestCompletion(t *testing.T) {
+	db := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(db)
+	checkedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	userID := uuid.New()
+	insertActiveUser(t, db, userID, "contest owner")
+
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt.AddDate(0, 0, -1), checkedAt.AddDate(0, 0, 1), nil)
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt, checkedAt.AddDate(0, 0, 3), nil)
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt.AddDate(0, 0, 1), checkedAt.AddDate(0, 0, 5), nil)
+	canceledAt := checkedAt.Add(-time.Hour)
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt.AddDate(0, 0, -1), checkedAt.AddDate(0, 0, 10), &canceledAt)
+
+	availableAfter, err := repo.FindRunningOwnedContestAvailableAfter(context.Background(), userID, checkedAt)
+	require.NoError(t, err)
+	require.NotNil(t, availableAfter)
+	assert.Equal(t, time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC), *availableAfter)
+}
+
+func TestAccountDeletionEligibilityAcceptsExactCompletionBoundary(t *testing.T) {
+	db := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(db)
+	checkedAt := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	userID := uuid.New()
+	insertActiveUser(t, db, userID, "contest owner")
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt.AddDate(0, 0, -2), checkedAt.AddDate(0, 0, -1), nil)
+
+	availableAfter, err := repo.FindRunningOwnedContestAvailableAfter(context.Background(), userID, checkedAt)
+	require.NoError(t, err)
+	assert.Nil(t, availableAfter)
+}
+
+func TestAccountDeletionLockRejectsRunningOwnerWithoutPersistingLock(t *testing.T) {
+	db := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(db)
+	checkedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	userID := uuid.New()
+	insertActiveUser(t, db, userID, "contest owner")
+	insertDeletionTestContest(t, db, uuid.New(), userID, checkedAt, checkedAt.AddDate(0, 0, 1), nil)
+
+	assert.ErrorIs(t, lockAccount(t, repo, userID, checkedAt), domain.ErrRunningContestOwned)
+	var lockedAt sql.NullTime
+	require.NoError(t, db.QueryRow("select deletion_locked_at from users where id = $1", userID).Scan(&lockedAt))
+	assert.False(t, lockedAt.Valid)
+}
+
+func TestAccountDeletionLockWaitsForContestCreationAndRejects(t *testing.T) {
+	db := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(db)
+	checkedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	userID := uuid.New()
+	insertActiveUser(t, db, userID, "contest owner")
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, lockUserForMutation(context.Background(), repo.q.WithTx(tx), userID))
+	_, err = tx.Exec(`
+		insert into contests (
+			id, owner_user_id, owner_user_display_name, private, contest_start, contest_end,
+			registration_end, title, activity_type_id_allow_list, official
+		) values ($1, $2, 'contest owner', false, $3, $4, $3, 'racing contest', array[1], false)
+	`, uuid.New(), userID, checkedAt, checkedAt.AddDate(0, 0, 1))
+	require.NoError(t, err)
+
+	lockResult := make(chan error, 1)
+	go func() { lockResult <- lockAccount(t, repo, userID, checkedAt) }()
+	select {
+	case err := <-lockResult:
+		require.Failf(t, "deletion lock did not wait", "returned early with %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	assert.ErrorIs(t, <-lockResult, domain.ErrRunningContestOwned)
+}

--- a/services/immersion-api/storage/postgres/repository/accountdeletionlock.go
+++ b/services/immersion-api/storage/postgres/repository/accountdeletionlock.go
@@ -26,11 +26,43 @@ func lockUserForMutation(ctx context.Context, q *postgres.Queries, userID uuid.U
 }
 
 func (r *Repository) LockAccountForDeletion(ctx context.Context, req *domain.AccountDeletionLockRequest) error {
-	if err := r.q.LockAccountForDeletion(ctx, postgres.LockAccountForDeletionParams{
+	tx, err := r.psql.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("could not start transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := r.q.WithTx(tx)
+	if err := qtx.EnsureAccountDeletionTarget(ctx, req.UserID); err != nil {
+		return fmt.Errorf("could not ensure account deletion target: %w", err)
+	}
+	target, err := qtx.LockAccountDeletionTarget(ctx, req.UserID)
+	if err != nil {
+		return fmt.Errorf("could not lock account deletion target: %w", err)
+	}
+	if target.DeletionLockedAt.Valid || target.DeletedAt.Valid {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("could not commit existing account deletion lock: %w", err)
+		}
+		return nil
+	}
+
+	availableAfter, err := findRunningOwnedContestAvailableAfter(ctx, qtx, req.UserID, req.LockedAt())
+	if err != nil {
+		return fmt.Errorf("could not check running contest ownership: %w", err)
+	}
+	if availableAfter != nil {
+		return domain.ErrRunningContestOwned
+	}
+
+	if err := qtx.SetAccountDeletionLock(ctx, postgres.SetAccountDeletionLockParams{
 		ID:       req.UserID,
 		LockedAt: sql.NullTime{Time: req.LockedAt(), Valid: true},
 	}); err != nil {
-		return fmt.Errorf("could not lock account for deletion: %w", err)
+		return fmt.Errorf("could not set account deletion lock: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("could not commit account deletion lock: %w", err)
 	}
 	return nil
 }

--- a/services/immersion-api/storage/postgres/repository/accountdeletionscrub.go
+++ b/services/immersion-api/storage/postgres/repository/accountdeletionscrub.go
@@ -33,14 +33,11 @@ func (r *Repository) ScrubAccount(ctx context.Context, req *domain.AccountDeleti
 		return domain.ErrAccountDeletionNotLocked
 	}
 
-	hasRunningContest, err := qtx.HasRunningOwnedContest(ctx, postgres.HasRunningOwnedContestParams{
-		UserID:    req.UserID,
-		DeletedAt: req.DeletedAt(),
-	})
+	availableAfter, err := findRunningOwnedContestAvailableAfter(ctx, qtx, req.UserID, req.DeletedAt())
 	if err != nil {
 		return fmt.Errorf("could not classify owned contests: %w", err)
 	}
-	if hasRunningContest {
+	if availableAfter != nil {
 		return domain.ErrRunningContestOwned
 	}
 

--- a/services/immersion-api/storage/postgres/users.sql.go
+++ b/services/immersion-api/storage/postgres/users.sql.go
@@ -14,6 +14,21 @@ import (
 	"github.com/lib/pq"
 )
 
+const ensureAccountDeletionTarget = `-- name: EnsureAccountDeletionTarget :exec
+insert into users (
+  id,
+  display_name
+) values (
+  $1,
+  ''
+) on conflict (id) do nothing
+`
+
+func (q *Queries) EnsureAccountDeletionTarget(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, ensureAccountDeletionTarget, id)
+	return err
+}
+
 const findUserDisplayNames = `-- name: FindUserDisplayNames :many
 select id, display_name from users where id = any($1::uuid[])
 `
@@ -46,30 +61,6 @@ func (q *Queries) FindUserDisplayNames(ctx context.Context, ids []uuid.UUID) ([]
 	return items, nil
 }
 
-const lockAccountForDeletion = `-- name: LockAccountForDeletion :exec
-insert into users (
-  id,
-  display_name,
-  deletion_locked_at
-) values (
-  $1,
-  '',
-  $2
-) on conflict (id) do
-update set
-  deletion_locked_at = coalesce(users.deletion_locked_at, excluded.deletion_locked_at)
-`
-
-type LockAccountForDeletionParams struct {
-	ID       uuid.UUID
-	LockedAt sql.NullTime
-}
-
-func (q *Queries) LockAccountForDeletion(ctx context.Context, arg LockAccountForDeletionParams) error {
-	_, err := q.db.ExecContext(ctx, lockAccountForDeletion, arg.ID, arg.LockedAt)
-	return err
-}
-
 const lockUserForMutation = `-- name: LockUserForMutation :one
 select id, display_name, created_at, updated_at, deletion_locked_at, deleted_at
 from users
@@ -89,6 +80,22 @@ func (q *Queries) LockUserForMutation(ctx context.Context, id uuid.UUID) (User, 
 		&i.DeletedAt,
 	)
 	return i, err
+}
+
+const setAccountDeletionLock = `-- name: SetAccountDeletionLock :exec
+update users
+set deletion_locked_at = coalesce(deletion_locked_at, $1)
+where id = $2
+`
+
+type SetAccountDeletionLockParams struct {
+	LockedAt sql.NullTime
+	ID       uuid.UUID
+}
+
+func (q *Queries) SetAccountDeletionLock(ctx context.Context, arg SetAccountDeletionLockParams) error {
+	_, err := q.db.ExecContext(ctx, setAccountDeletionLock, arg.LockedAt, arg.ID)
+	return err
 }
 
 const upsertUser = `-- name: UpsertUser :one


### PR DESCRIPTION
## Summary

- add a profile-api-only internal eligibility endpoint that reports when a running owned contest stops blocking deletion
- share the running-contest predicate between eligibility, locking, and scrubbing
- make account-deletion locking transactional so the running-owner check and deletion lock are atomic with user mutations
- cover the completion boundary and the contest-creation/deletion-lock race against databases built from the full migration set

This PR provides the immersion-api primitive; it does not yet wire the profile-api deletion-request flow to call it. It contains no schema migration.

## API

`POST /internal/v1/account-deletion-eligibility` with `user_id` returns:

- `204` when deletion is currently eligible
- `409` with `running_contest_owned` and `available_after` when an owned contest is running

The existing lock endpoint also returns `409` for a running owner, closing the preflight-to-lock race.

## Validation

- `bazel build //services/...`
- `IMMERSION_TEST_POSTGRES_URL=... bazel test //services/... --test_output=errors --nocache_test_results` (25/25 targets passed, including fresh full-migration PostgreSQL databases)
- `./scripts/generate-sqlc.sh` (stable)
- internal OpenAPI generation (stable)
- `bazel run //:gazelle -- -mode=diff`
- `git diff --check`