### PR TITLE
Fix Flipt recovery snapshot confirmation

### DIFF
--- a/services/common/client/flipt/client.go
+++ b/services/common/client/flipt/client.go
@@ -310,11 +310,7 @@ func (t *observedTransport) RoundTrip(request *http.Request) (*http.Response, er
 		}
 	case http.StatusNotModified:
 		if t.state != nil {
-			if t.state.canAcceptNotModified(request.Header.Get("If-None-Match")) {
-				t.state.unchangedSnapshot()
-			} else {
-				t.state.failed()
-			}
+			t.state.snapshotNotModified(request.Header.Get("If-None-Match"))
 		}
 	default:
 		if t.state != nil {
@@ -400,8 +396,31 @@ func (s *providerFetchState) confirmPendingSnapshot() {
 	}
 }
 
-func (s *providerFetchState) unchangedSnapshot() {
+func (s *providerFetchState) snapshotNotModified(etag string) {
 	s.mu.Lock()
+	accepted := etag != ""
+	if s.pending {
+		accepted = accepted && etag == s.pendingETag
+		if accepted {
+			s.hasSnapshot = true
+			s.confirmedETag = s.pendingETag
+		}
+	} else {
+		accepted = accepted && s.hasSnapshot && etag == s.confirmedETag
+	}
+	if !accepted {
+		s.observed = true
+		s.stale = true
+		s.pending = false
+		s.recovered = false
+		s.pendingETag = ""
+		s.mu.Unlock()
+		if s.observer != nil {
+			s.observer.ObserveProviderError("fetch")
+		}
+		return
+	}
+
 	wasStale := s.stale
 	s.observed = true
 	s.stale = false
@@ -425,12 +444,6 @@ func (s *providerFetchState) failed() {
 	if s.observer != nil {
 		s.observer.ObserveProviderError("fetch")
 	}
-}
-
-func (s *providerFetchState) canAcceptNotModified(etag string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.hasSnapshot && etag != "" && etag == s.confirmedETag
 }
 
 func (s *providerFetchState) isStale(sdkError bool) bool {

--- a/services/common/client/flipt/client_test.go
+++ b/services/common/client/flipt/client_test.go
@@ -539,6 +539,39 @@ func TestObservedTransportTracksRefreshesAndBoundedFetchErrors(t *testing.T) {
 	assert.Equal(t, []string{"fetch"}, providerErrors)
 }
 
+func TestObservedTransportConfirmsRecoveredSnapshotOnMatchingNotModified(t *testing.T) {
+	observer := &recordingObserver{}
+	statuses := []int{http.StatusOK, http.StatusNotModified}
+	state := newProviderFetchState("default", observer)
+	transport := &observedTransport{
+		state: state,
+		base: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+			status := statuses[0]
+			statuses = statuses[1:]
+			body := io.ReadCloser(http.NoBody)
+			header := make(http.Header)
+			if status == http.StatusOK {
+				body = io.NopCloser(strings.NewReader(booleanSnapshot(nil)))
+				header.Set("ETag", `"recovered"`)
+			}
+			return &http.Response{StatusCode: status, Body: body, Header: header}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "http://flipt/snapshot", nil)
+
+	_, err := transport.RoundTrip(request)
+	require.NoError(t, err)
+	request.Header.Set("If-None-Match", `"recovered"`)
+	_, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+
+	_, refreshes, providerErrors := observer.snapshot()
+	assert.Equal(t, 1, refreshes)
+	assert.Empty(t, providerErrors)
+	assert.False(t, state.isStale(false))
+	assert.True(t, state.canAcceptNotModified(`"recovered"`))
+}
+
 func TestFetchStateOnlyAcceptsNotModifiedForConfirmedETag(t *testing.T) {
 	state := newProviderFetchState("default", nil)
 	state.snapshotReceived(`"v1"`)

--- a/services/common/client/flipt/client_test.go
+++ b/services/common/client/flipt/client_test.go
@@ -541,7 +541,7 @@ func TestObservedTransportTracksRefreshesAndBoundedFetchErrors(t *testing.T) {
 
 func TestObservedTransportConfirmsRecoveredSnapshotOnMatchingNotModified(t *testing.T) {
 	observer := &recordingObserver{}
-	statuses := []int{http.StatusOK, http.StatusNotModified}
+	statuses := []int{http.StatusOK, http.StatusNotModified, http.StatusNotModified}
 	state := newProviderFetchState("default", observer)
 	transport := &observedTransport{
 		state: state,
@@ -564,22 +564,42 @@ func TestObservedTransportConfirmsRecoveredSnapshotOnMatchingNotModified(t *test
 	request.Header.Set("If-None-Match", `"recovered"`)
 	_, err = transport.RoundTrip(request)
 	require.NoError(t, err)
+	_, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+
+	_, refreshes, providerErrors := observer.snapshot()
+	assert.Equal(t, 2, refreshes)
+	assert.Empty(t, providerErrors)
+	assert.False(t, state.isStale(false))
+}
+
+func TestFetchStateRejectsMismatchedPendingETagWithoutReplacingConfirmedSnapshot(t *testing.T) {
+	observer := &recordingObserver{}
+	state := newProviderFetchState("default", observer)
+	state.snapshotReceived(`"v1"`)
+	state.confirmPendingSnapshot()
+	state.snapshotReceived(`"v2"`)
+
+	state.snapshotNotModified(`"v1"`)
 
 	_, refreshes, providerErrors := observer.snapshot()
 	assert.Equal(t, 1, refreshes)
-	assert.Empty(t, providerErrors)
+	assert.Equal(t, []string{"fetch"}, providerErrors)
+	assert.True(t, state.isStale(false))
+
+	state.snapshotNotModified(`"v1"`)
+
+	_, refreshes, providerErrors = observer.snapshot()
+	assert.Equal(t, 2, refreshes)
+	assert.Equal(t, []string{"fetch"}, providerErrors)
 	assert.False(t, state.isStale(false))
-	assert.True(t, state.canAcceptNotModified(`"recovered"`))
-}
 
-func TestFetchStateOnlyAcceptsNotModifiedForConfirmedETag(t *testing.T) {
-	state := newProviderFetchState("default", nil)
-	state.snapshotReceived(`"v1"`)
-	state.confirmPendingSnapshot()
-	state.failed()
+	state.snapshotNotModified("")
 
-	assert.False(t, state.canAcceptNotModified(`"uninstalled-v2"`))
-	assert.True(t, state.canAcceptNotModified(`"v1"`))
+	_, refreshes, providerErrors = observer.snapshot()
+	assert.Equal(t, 2, refreshes)
+	assert.Equal(t, []string{"fetch", "fetch"}, providerErrors)
+	assert.True(t, state.isStale(false))
 }
 
 func TestCloseReleasesSDK(t *testing.T) {


### PR DESCRIPTION
## What changed

- atomically confirm a recovered Flipt snapshot when the SDK follows its valid `200` with a matching `304 Not Modified`
- preserve the confirmed ETag for subsequent refreshes
- continue rejecting empty, mismatched, and unconfirmed ETags
- retain the last-known-good snapshot when a newer pending snapshot receives a mismatched `304`

## Why

Production exposed a recovery edge case: after Flipt became available, immersion-api fetched a valid snapshot, but no authenticated evaluation confirmed it before the next poll. The following `304` was rejected, leaving config age at `-1` and telemetry stale even though the SDK had accepted the snapshot.

The new transition validates and updates the ETag state under one mutex, avoiding a check/mutation race and allowing recovery without restarting immersion-api.

## Test-first history

1. `ff4c493f` adds the failing production-sequence regression test.
2. `1b18e35c` implements the atomic transition and strengthens ETag safety coverage.

## Validation

- `gofmt` clean
- `git diff --check`
- uncached `//services/common/client/flipt:flipt_test`
- `bazel build //services/...`
- `bazel test //services/...`