### PR TITLE
Add idempotent Kratos deletion primitives

### DIFF
--- a/services/common/client/kratos/BUILD.bazel
+++ b/services/common/client/kratos/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kratos",
@@ -8,5 +8,16 @@ go_library(
     deps = [
         "@com_github_google_uuid//:uuid",
         "@com_github_ory_kratos_client_go//:kratos-client-go",
+    ],
+)
+
+go_test(
+    name = "kratos_test",
+    srcs = ["client_test.go"],
+    deps = [
+        ":kratos",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/services/common/client/kratos/client.go
+++ b/services/common/client/kratos/client.go
@@ -56,3 +56,45 @@ func (c *Client) ListIdentities(ctx context.Context, perPage int64, page int64) 
 	}
 	return identities, nil
 }
+
+func (c *Client) DeactivateIdentity(ctx context.Context, id uuid.UUID) error {
+	statePatch := kratosapi.NewJsonPatch("replace", "/state")
+	statePatch.SetValue(kratosapi.IDENTITYSTATE_INACTIVE)
+	req := c.client.IdentityApi.PatchIdentity(ctx, id.String()).JsonPatch([]kratosapi.JsonPatch{*statePatch})
+	_, res, err := c.client.IdentityApi.PatchIdentityExecute(req)
+	if err != nil {
+		if responseStatus(res, http.StatusNotFound) {
+			return nil
+		}
+		return fmt.Errorf("could not deactivate identity: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) DeleteIdentitySessions(ctx context.Context, id uuid.UUID) error {
+	req := c.client.IdentityApi.DeleteIdentitySessions(ctx, id.String())
+	res, err := c.client.IdentityApi.DeleteIdentitySessionsExecute(req)
+	if err != nil {
+		if responseStatus(res, http.StatusNotFound) {
+			return nil
+		}
+		return fmt.Errorf("could not delete identity sessions: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) DeleteIdentity(ctx context.Context, id uuid.UUID) error {
+	req := c.client.IdentityApi.DeleteIdentity(ctx, id.String())
+	res, err := c.client.IdentityApi.DeleteIdentityExecute(req)
+	if err != nil {
+		if responseStatus(res, http.StatusNotFound) {
+			return nil
+		}
+		return fmt.Errorf("could not delete identity: %w", err)
+	}
+	return nil
+}
+
+func responseStatus(res *http.Response, status int) bool {
+	return res != nil && res.StatusCode == status
+}

--- a/services/common/client/kratos/client_test.go
+++ b/services/common/client/kratos/client_test.go
@@ -1,0 +1,133 @@
+package kratos_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonkratos "github.com/tadoku/tadoku/services/common/client/kratos"
+)
+
+func TestDeactivateIdentityOnlyPatchesState(t *testing.T) {
+	identityID := uuid.New()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/admin/identities/"+identityID.String(), req.URL.Path)
+		assert.Equal(t, http.MethodPatch, req.Method)
+		w.Header().Set("Content-Type", "application/json")
+		var body []map[string]interface{}
+		if !assert.NoError(t, json.NewDecoder(req.Body).Decode(&body)) {
+			return
+		}
+		assert.Equal(t, []map[string]interface{}{{
+			"op":    "replace",
+			"path":  "/state",
+			"value": "inactive",
+		}}, body)
+		_, _ = w.Write([]byte(identityJSON(identityID, "inactive")))
+	}))
+	defer server.Close()
+
+	err := commonkratos.NewClient(server.URL).DeactivateIdentity(context.Background(), identityID)
+
+	require.NoError(t, err)
+}
+
+func TestDeactivateIdentityIsIdempotent(t *testing.T) {
+	for name, status := range map[string]int{
+		"already inactive": http.StatusOK,
+		"missing identity": http.StatusNotFound,
+	} {
+		t.Run(name, func(t *testing.T) {
+			identityID := uuid.New()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				if status == http.StatusOK {
+					_, _ = w.Write([]byte(identityJSON(identityID, "inactive")))
+				}
+			}))
+			defer server.Close()
+
+			err := commonkratos.NewClient(server.URL).DeactivateIdentity(context.Background(), identityID)
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDeactivateIdentityReturnsDependencyErrors(t *testing.T) {
+	identityID := uuid.New()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err := commonkratos.NewClient(server.URL).DeactivateIdentity(context.Background(), identityID)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deactivate identity")
+}
+
+func TestDeleteIdentitySessions(t *testing.T) {
+	testIdempotentDelete(t, "/admin/identities/%s/sessions", "delete identity sessions", func(client *commonkratos.Client, identityID uuid.UUID) error {
+		return client.DeleteIdentitySessions(context.Background(), identityID)
+	})
+}
+
+func TestDeleteIdentity(t *testing.T) {
+	testIdempotentDelete(t, "/admin/identities/%s", "delete identity", func(client *commonkratos.Client, identityID uuid.UUID) error {
+		return client.DeleteIdentity(context.Background(), identityID)
+	})
+}
+
+func testIdempotentDelete(
+	t *testing.T,
+	pathFormat string,
+	wantError string,
+	execute func(*commonkratos.Client, uuid.UUID) error,
+) {
+	t.Helper()
+	for name, status := range map[string]int{
+		"success":            http.StatusNoContent,
+		"already missing":    http.StatusNotFound,
+		"dependency failure": http.StatusInternalServerError,
+	} {
+		t.Run(name, func(t *testing.T) {
+			identityID := uuid.New()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, strings.Replace(pathFormat, "%s", identityID.String(), 1), req.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			err := execute(commonkratos.NewClient(server.URL), identityID)
+			if status == http.StatusInternalServerError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), wantError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func identityJSON(identityID uuid.UUID, state string) string {
+	return `{
+		"id":"` + identityID.String() + `",
+		"schema_id":"user",
+		"schema_url":"http://kratos/schemas/user",
+		"state":"` + state + `",
+		"traits":{"display_name":"Keep Me","email":"keep@example.com"},
+		"metadata_admin":{"support":"keep"},
+		"metadata_public":{"theme":"keep"}
+	}`
+}


### PR DESCRIPTION
## Summary

- add a narrowly scoped Kratos identity deactivation operation using JSON Patch on `/state` only
- add operations to delete/invalidate every session for an identity and to delete the identity itself
- treat Kratos `404` responses as idempotent success for all three deletion effects
- cover exact HTTP methods, paths, deactivation payload, successful responses, already-missing identities, and dependency failures

This PR only adds shared client primitives. It does not invoke them, start the deletion worker, or change live identity/session state.

## Safety

Deactivation sends exactly `[{"op":"replace","path":"/state","value":"inactive"}]`. It does not fetch or rewrite traits, metadata, or credentials.

## Validation

- `bazel run //:gazelle -- -mode=diff`
- `bazel build //services/...`
- `bazel test //services/... --test_output=errors` (28/28 targets passed)
- `git diff --check`