### PR TITLE
Add tag-based platform scoring rules

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0026_platform_scoring_rule_set_v4_reading_page_tags.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0026_platform_scoring_rule_set_v4_reading_page_tags.down.sql
@@ -1,0 +1,15 @@
+begin;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 3
+);
+
+delete from scoring_rule_sets
+where scope = 'platform'
+  and version = 4;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0026_platform_scoring_rule_set_v4_reading_page_tags.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0026_platform_scoring_rule_set_v4_reading_page_tags.up.sql
@@ -1,0 +1,96 @@
+begin;
+
+insert into scoring_rule_sets (
+  scope,
+  version,
+  status,
+  published_at
+) values (
+  'platform',
+  4,
+  'published',
+  now()
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+) select
+  (
+    select id
+    from scoring_rule_sets
+    where scope = 'platform'
+      and version = 4
+  ),
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+from scoring_rules
+where rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 3
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+) select
+  rule_set.id,
+  rule.priority,
+  rule.stackable,
+  rule.activity_id,
+  rule.unit_key,
+  rule.language_code,
+  rule.tag,
+  rule.score_source,
+  rule.rate
+from scoring_rule_sets as rule_set
+cross join (
+  values
+    (80, false, 1, 'reading_page', 'jpn', 'two_column', 'amount', 1.6),
+    (90, false, 1, 'reading_page', null, 'comic', 'amount', 0.2),
+    (95, false, 1, 'reading_page', null, 'manga', 'amount', 0.2),
+    (420, true, 4, null, null, 'dense', 'duration_minutes', 1.4)
+) as rule (
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+)
+where rule_set.scope = 'platform'
+  and rule_set.version = 4;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 4
+);
+
+commit;

--- a/services/immersion-api/storage/postgres/repository/repo_findscoringruleset_test.go
+++ b/services/immersion-api/storage/postgres/repository/repo_findscoringruleset_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -10,7 +11,81 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tadoku/tadoku/services/immersion-api/domain"
 	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres"
+	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres/postgrestest"
 )
+
+func TestActivePlatformScoringRulesSupportReadingPageTags(t *testing.T) {
+	testDB := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(testDB)
+	ruleSet, err := repo.FindActivePlatformScoringRuleSet(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ruleSet)
+	assert.Equal(t, int32(4), ruleSet.Version)
+
+	amount := float32(10)
+	tests := []struct {
+		name         string
+		unitKey      string
+		languageCode string
+		tags         []string
+		wantScore    float32
+	}{
+		{name: "ordinary pages", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", wantScore: 10},
+		{name: "Japanese two-column page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"two_column"}, wantScore: 16},
+		{name: "English two-column tag remains informational", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"two_column"}, wantScore: 10},
+		{name: "comic page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"comic"}, wantScore: 2},
+		{name: "manga page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"manga"}, wantScore: 2},
+		{name: "legacy two-column page unit", unitKey: domain.UnitKeyReadingTwoColumnPage, languageCode: "jpn", wantScore: 16},
+		{name: "legacy comic page unit", unitKey: domain.UnitKeyReadingComicPage, languageCode: "eng", wantScore: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, evaluateErr := domain.EvaluateScoringRuleSet(domain.ScoringInput{
+				ActivityID:   1,
+				UnitKey:      tt.unitKey,
+				LanguageCode: tt.languageCode,
+				Tags:         tt.tags,
+				Amount:       &amount,
+			}, *ruleSet)
+
+			require.NoError(t, evaluateErr)
+			assert.Equal(t, tt.wantScore, result.Score)
+		})
+	}
+}
+
+func TestActivePlatformScoringRulesSupportDenseSpeakingDuration(t *testing.T) {
+	testDB := postgrestest.OpenMigratedDatabase(t)
+	repo := NewRepository(testDB)
+	ruleSet, err := repo.FindActivePlatformScoringRuleSet(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ruleSet)
+	assert.Equal(t, int32(4), ruleSet.Version)
+
+	durationSeconds := int32(600)
+	tests := []struct {
+		name      string
+		tags      []string
+		wantScore float32
+	}{
+		{name: "plain speaking", wantScore: 5},
+		{name: "dense speaking", tags: []string{"dense"}, wantScore: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, evaluateErr := domain.EvaluateScoringRuleSet(domain.ScoringInput{
+				ActivityID:      4,
+				Tags:            tt.tags,
+				DurationSeconds: &durationSeconds,
+			}, *ruleSet)
+
+			require.NoError(t, evaluateErr)
+			assert.InDelta(t, tt.wantScore, result.Score, 0.0001)
+		})
+	}
+}
 
 func TestScoringRuleSetToDomain(t *testing.T) {
 	ruleSetID := uuid.New()


### PR DESCRIPTION
## Summary

- publish platform scoring rule set v4 while preserving every v3 legacy-unit rule
- score Japanese Page logs tagged two_column at 1.6 points per page
- score Page logs tagged comic or manga at 0.2 points per page
- restore dense Speaking duration scoring with the legacy-equivalent 1.4 multiplier
- keep rollback behavior explicit by reactivating v3 before deleting v4

## Compatibility

Existing Comic page, 2 Column page, and dense-minute unit submissions retain their previous scores. Historical score snapshots are not recalculated. The frontend selector cleanup must remain separate and deploy only after this migration is deployed.

## Verification

- PostgreSQL 16 migration integration tests for Page tags, legacy reading units, and dense Speaking duration
- bazel test //services/immersion-api/domain:domain_test //services/immersion-api/storage/postgres/repository:repository_test
- bazel build //services/immersion-api/...

**Posted by gpt-5.6-sol**