### PR TITLE
Group score modifier tags

### DIFF
--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -44,8 +44,11 @@ export const LogFormV2 = ({
     activityId: defaultActivity.id,
     amountUnit:
       defaultActivityInputType === 'amount_primary'
-        ? options.units.filter(it => it.log_activity_id === defaultActivity.id)[0]
-            ?.id
+        ? filterUnits(
+            options.units,
+            defaultActivity.id,
+            originalDefaultValues?.languageCode,
+          )[0]?.id
         : undefined,
     allUnits: options.units,
     allActivities: options.activities,

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.test.ts
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.test.ts
@@ -4,7 +4,7 @@ vi.mock('next/config', () => ({
   default: () => ({ publicRuntimeConfig: { apiEndpoint: '' } }),
 }))
 
-import { NewLogV2APISchema } from './domain'
+import { filterUnits, NewLogV2APISchema } from './domain'
 
 const amountActivity = {
   id: 101,
@@ -96,5 +96,46 @@ describe('NewLogV2APISchema', () => {
     })
 
     expect(result.success).toBe(false)
+  })
+})
+
+describe('filterUnits', () => {
+  it('keeps legacy reading page variants out of the V2 amount selector', () => {
+    const readingUnits = [
+      {
+        id: 'page',
+        unit_key: 'reading_page',
+        log_activity_id: 1,
+        name: 'Page',
+        modifier: 1,
+      },
+      {
+        id: 'two-column-page',
+        unit_key: 'reading_two_column_page',
+        log_activity_id: 1,
+        name: '2 Column page',
+        modifier: 1.6,
+        language_code: 'jpn',
+      },
+      {
+        id: 'comic-page',
+        unit_key: 'reading_comic_page',
+        log_activity_id: 1,
+        name: 'Comic page',
+        modifier: 0.2,
+      },
+      {
+        id: 'sentence',
+        unit_key: 'reading_sentence',
+        log_activity_id: 1,
+        name: 'Sentence',
+        modifier: 0.05,
+      },
+    ]
+
+    expect(filterUnits(readingUnits, 1, 'jpn').map(unit => unit.unit_key)).toEqual([
+      'reading_page',
+      'reading_sentence',
+    ])
   })
 })

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
@@ -1,8 +1,20 @@
 import { z } from 'zod'
 import { Activity, Unit } from '@app/immersion/api'
-import { filterUnits } from '@app/immersion/NewLogForm/domain'
+import { filterUnits as filterLegacyUnits } from '@app/immersion/NewLogForm/domain'
 
-export { filterUnits }
+const legacyReadingUnitKeys = new Set([
+  'reading_two_column_page',
+  'reading_comic_page',
+])
+
+export const filterUnits = (
+  units: Unit[],
+  activityId: number | undefined,
+  languageCode: string | undefined,
+) =>
+  filterLegacyUnits(units, activityId, languageCode).filter(
+    unit => !legacyReadingUnitKeys.has(unit.unit_key),
+  )
 
 const optionalNumber = z.preprocess(
   value =>

--- a/frontend/apps/webv2/app/immersion/components/TagsSidebar.test.tsx
+++ b/frontend/apps/webv2/app/immersion/components/TagsSidebar.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { render, screen, within } from '@testing-library/react'
+import React from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TagsSidebar } from './TagsSidebar'
+
+const TagsSidebarForm = ({ activityId }: { activityId: number }) => {
+  const methods = useForm({ defaultValues: { tags: [] } })
+
+  return (
+    <FormProvider {...methods}>
+      <TagsSidebar activityId={activityId} />
+    </FormProvider>
+  )
+}
+
+afterEach(() => document.body.replaceChildren())
+
+describe('TagsSidebar', () => {
+  it('groups reading modifiers above common tags without changing tag labels', () => {
+    render(<TagsSidebarForm activityId={1} />)
+
+    const modifiersHeading = screen.getByText('Score modifiers')
+    const commonHeading = screen.getByText('Common tags')
+    const modifiers = modifiersHeading.closest('section')
+    const common = commonHeading.closest('section')
+
+    expect(
+      modifiersHeading.compareDocumentPosition(commonHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(modifiers).not.toBeNull()
+    expect(common).not.toBeNull()
+    expect(
+      within(modifiers!).getByRole('button', { name: 'manga' }),
+    ).toBeTruthy()
+    expect(
+      within(modifiers!).getByRole('button', { name: 'comic' }),
+    ).toBeTruthy()
+    expect(
+      within(modifiers!).getByRole('button', { name: 'two_column' }),
+    ).toBeTruthy()
+    expect(within(common!).getByRole('button', { name: 'book' })).toBeTruthy()
+  })
+
+  it.each([2, 4])('groups dense as a modifier for activity %s', activityId => {
+    render(<TagsSidebarForm activityId={activityId} />)
+
+    const modifiers = screen.getByText('Score modifiers').closest('section')
+
+    expect(modifiers).not.toBeNull()
+    expect(
+      within(modifiers!).getByRole('button', { name: 'dense' }),
+    ).toBeTruthy()
+  })
+
+  it('only shows common tags when an activity has no modifiers', () => {
+    render(<TagsSidebarForm activityId={3} />)
+
+    expect(screen.queryByText('Score modifiers')).toBeNull()
+    expect(screen.getByText('Common tags')).toBeTruthy()
+  })
+})

--- a/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
+++ b/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
@@ -1,9 +1,9 @@
+import React from 'react'
 import { useFormContext } from 'react-hook-form'
 
 interface ActivityTagSuggestion {
   tag: string
-  // Future: modifiers for score adjustments
-  // modifiers?: { unitId: string; multiplier: number }[]
+  modifier?: boolean
 }
 
 const activityTags: Record<number, ActivityTagSuggestion[]> = {
@@ -11,8 +11,9 @@ const activityTags: Record<number, ActivityTagSuggestion[]> = {
   1: [
     { tag: 'book' },
     { tag: 'ebook' },
-    { tag: 'manga' },
-    { tag: 'comic' },
+    { tag: 'manga', modifier: true },
+    { tag: 'comic', modifier: true },
+    { tag: 'two_column', modifier: true },
     { tag: 'fiction' },
     { tag: 'non-fiction' },
     { tag: 'web page' },
@@ -21,7 +22,7 @@ const activityTags: Record<number, ActivityTagSuggestion[]> = {
   ],
   // Listening
   2: [
-    { tag: 'dense' },
+    { tag: 'dense', modifier: true },
     { tag: 'audiobook' },
     { tag: 'podcast' },
     { tag: 'anime' },
@@ -41,6 +42,7 @@ const activityTags: Record<number, ActivityTagSuggestion[]> = {
   ],
   // Speaking
   4: [
+    { tag: 'dense', modifier: true },
     { tag: 'conversation' },
     { tag: 'presentation' },
     { tag: 'shadowing' },
@@ -64,9 +66,11 @@ interface TagsSidebarProps {
 export function TagsSidebar({ activityId }: TagsSidebarProps) {
   const { watch, getValues, setValue } = useFormContext()
   const tags: string[] = watch('tags') ?? []
-  const suggestions: ActivityTagSuggestion[] = activityId != null ? (activityTags[activityId] ?? []) : []
+  const allSuggestions = activityId != null ? (activityTags[activityId] ?? []) : []
+  const modifiers = allSuggestions.filter(({ modifier }) => modifier)
+  const suggestions = allSuggestions.filter(({ modifier }) => !modifier)
 
-  if (suggestions.length === 0) return null
+  if (modifiers.length === 0 && suggestions.length === 0) return null
 
   const isAtLimit = tags.length >= MAX_TAGS
 
@@ -79,29 +83,45 @@ export function TagsSidebar({ activityId }: TagsSidebarProps) {
     }
   }
 
+  const renderSuggestions = (items: ActivityTagSuggestion[]) => (
+    <div className="flex flex-wrap gap-2">
+      {items.map(({ tag }) => {
+        const isSelected = tags.includes(tag)
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => handleToggle(tag)}
+            disabled={!isSelected && isAtLimit}
+            className={`tag cursor-pointer transition-colors border border-b-2 border-black/5 lg:border-black/15 bg-black/5 lg:bg-white ${
+              isSelected ? 'opacity-70 line-through' : 'hover:bg-slate-50'
+            } ${
+              !isSelected && isAtLimit
+                ? 'opacity-50 cursor-not-allowed'
+                : ''
+            }`}
+          >
+            {tag}
+          </button>
+        )
+      })}
+    </div>
+  )
+
   return (
-    <div className="v-stack gap-2 mt-4 lg:mt-0">
-      <span className="subtitle text-sm">Common tags</span>
-      <div className="flex flex-wrap gap-2">
-        {suggestions.map(({ tag }) => {
-          const isSelected = tags.includes(tag)
-          return (
-            <button
-              key={tag}
-              type="button"
-              onClick={() => handleToggle(tag)}
-              disabled={!isSelected && isAtLimit}
-              className={`tag cursor-pointer transition-colors border border-b-2 border-black/5 lg:border-black/15 bg-black/5 lg:bg-white ${
-                isSelected
-                  ? 'opacity-70 line-through'
-                  : 'hover:bg-slate-50'
-              } ${!isSelected && isAtLimit ? 'opacity-50 cursor-not-allowed' : ''}`}
-            >
-              {tag}
-            </button>
-          )
-        })}
-      </div>
+    <div className="v-stack gap-4 mt-4 lg:mt-0">
+      {modifiers.length > 0 && (
+        <section className="v-stack gap-2">
+          <span className="subtitle text-sm">Score modifiers</span>
+          {renderSuggestions(modifiers)}
+        </section>
+      )}
+      {suggestions.length > 0 && (
+        <section className="v-stack gap-2">
+          <span className="subtitle text-sm">Common tags</span>
+          {renderSuggestions(suggestions)}
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- hide legacy Comic page and 2 Column page units from the V2 log amount selector while leaving legacy flows compatible
- add a simple modifier boolean to the existing activity tag suggestions
- group modifier tags above the unchanged Common tags chips
- mark manga, comic, two_column, and dense as score modifiers
- keep the existing tag labels and chip design without displaying rates or other explanatory text

## Deployment prerequisite

Platform scoring rule set v4 from #841 is deployed before this application change. Production verification showed schema migration 26 clean and the expected tag rules active.

## Verification

- 9 focused Vitest tests passed
- pnpm --filter webv2 lint passed
- pnpm build passed for the complete frontend workspace
- git diff --check passed

## Note

The standalone webv2 TypeScript command still encounters the existing unrelated overload error in app/feature-flags/client.test.tsx:228. The full production build succeeds.

**Posted by gpt-5.6-sol**