### PR TITLE
Add Content schema to the canonical database

### DIFF
--- a/services/content-api/storage/postgres/migrations/BUILD.bazel
+++ b/services/content-api/storage/postgres/migrations/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
+filegroup(
+    name = "up_files",
+    srcs = glob(["*.up.sql"]),
+    visibility = ["//services/immersion-api/storage/postgres/migrations:__pkg__"],
+)
+
 pkg_tar(
     name = "tar",
     srcs = glob(["**/*.sql"]),

--- a/services/immersion-api/storage/postgres/migrations/0027_content_schema.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0027_content_schema.down.sql
@@ -1,0 +1,9 @@
+begin;
+
+drop table announcements;
+drop table posts_content;
+drop table posts;
+drop table pages_content;
+drop table pages;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0027_content_schema.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0027_content_schema.up.sql
@@ -1,0 +1,68 @@
+begin;
+
+create table pages (
+  id uuid primary key default uuid_generate_v4(),
+  "namespace" varchar(50) not null,
+  slug varchar(200) not null,
+  current_content_id uuid not null,
+  published_at timestamp,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  deleted_at timestamp
+);
+
+create unique index pages_slug on pages("namespace", slug);
+create index pages_namespace on pages("namespace");
+
+create table pages_content (
+  id uuid primary key default uuid_generate_v4(),
+  page_id uuid not null,
+  title text not null,
+  html text not null,
+  created_at timestamp not null default now()
+);
+
+create index pages_content_page_id on pages_content(page_id);
+
+create table posts (
+  id uuid primary key default uuid_generate_v4(),
+  "namespace" varchar(50) not null,
+  slug varchar(200) not null,
+  current_content_id uuid not null,
+  published_at timestamp,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  deleted_at timestamp
+);
+
+create unique index posts_slug on posts("namespace", slug);
+create index posts_namespace on posts("namespace");
+
+create table posts_content (
+  id uuid primary key default uuid_generate_v4(),
+  post_id uuid not null,
+  title text not null,
+  content text not null,
+  created_at timestamp not null default now()
+);
+
+create index posts_content_post_id on posts_content(post_id);
+
+create table announcements (
+  id uuid primary key default uuid_generate_v4(),
+  "namespace" varchar(50) not null,
+  title text not null,
+  content text not null,
+  style varchar(20) not null default 'info',
+  href text,
+  starts_at timestamp not null,
+  ends_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  deleted_at timestamp
+);
+
+create index announcements_namespace on announcements("namespace");
+create index announcements_active on announcements("namespace", starts_at, ends_at) where deleted_at is null;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/BUILD.bazel
+++ b/services/immersion-api/storage/postgres/migrations/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_go//go:def.bzl", "go_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 filegroup(
@@ -12,4 +13,23 @@ pkg_tar(
     mode = "0644",
     package_dir = "/migrations",
     visibility = ["//services/immersion-api:__pkg__"],
+)
+
+go_test(
+    name = "migrations_test",
+    srcs = ["content_schema_convergence_test.go"],
+    data = [
+        ":up_files",
+        "//services/content-api/storage/postgres/migrations:up_files",
+    ],
+    env_inherit = ["IMMERSION_TEST_POSTGRES_URL"],
+    deps = [
+        "@com_github_golang_migrate_migrate_v4//:migrate",
+        "@com_github_golang_migrate_migrate_v4//database/postgres",
+        "@com_github_golang_migrate_migrate_v4//source/file",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_lib_pq//:pq",
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel",
+    ],
 )

--- a/services/immersion-api/storage/postgres/migrations/content_schema_convergence_test.go
+++ b/services/immersion-api/storage/postgres/migrations/content_schema_convergence_test.go
@@ -1,0 +1,125 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+const postgresTestURLVariable = "IMMERSION_TEST_POSTGRES_URL"
+
+func TestContentSchemaMatchesCanonicalSource(t *testing.T) {
+	target := openMigratedDatabase(t, "services/immersion-api/storage/postgres/migrations/0001_init.up.sql")
+	source := openMigratedDatabase(t, "services/content-api/storage/postgres/migrations/0001_create_pages.up.sql")
+	tables := []string{"announcements", "pages", "pages_content", "posts", "posts_content"}
+
+	require.Equal(t, schemaFingerprint(t, source, tables), schemaFingerprint(t, target, tables))
+	for _, table := range tables {
+		var count int64
+		err := target.QueryRow("select count(*) from " + pq.QuoteIdentifier(table)).Scan(&count)
+		require.NoError(t, err)
+		require.Zero(t, count, "canonical target table %s must start empty", table)
+	}
+
+	var version int
+	var dirty bool
+	require.NoError(t, target.QueryRow("select version, dirty from schema_migrations").Scan(&version, &dirty))
+	require.Equal(t, 27, version)
+	require.False(t, dirty)
+}
+
+func openMigratedDatabase(t *testing.T, firstMigrationRunfile string) *sql.DB {
+	t.Helper()
+
+	adminURL := os.Getenv(postgresTestURLVariable)
+	if adminURL == "" {
+		t.Skipf("%s is not set; skipping PostgreSQL integration test", postgresTestURLVariable)
+	}
+
+	parsedAdminURL, err := url.Parse(adminURL)
+	require.NoError(t, err)
+	require.Equal(t, "postgres", parsedAdminURL.Scheme)
+
+	adminDB, err := sql.Open("postgres", adminURL)
+	require.NoError(t, err)
+	require.NoError(t, adminDB.Ping())
+
+	databaseName := "schema_convergence_test_" + uuid.NewString()
+	_, err = adminDB.Exec(`create database ` + pq.QuoteIdentifier(databaseName))
+	require.NoError(t, err)
+
+	testDatabaseURL := *parsedAdminURL
+	testDatabaseURL.Path = "/" + databaseName
+	testDB, err := sql.Open("postgres", testDatabaseURL.String())
+	require.NoError(t, err)
+	require.NoError(t, testDB.Ping())
+	t.Cleanup(func() {
+		require.NoError(t, testDB.Close())
+		_, dropErr := adminDB.Exec(`drop database ` + pq.QuoteIdentifier(databaseName) + ` with (force)`)
+		require.NoError(t, dropErr)
+		require.NoError(t, adminDB.Close())
+	})
+
+	firstMigration, err := bazel.Runfile(firstMigrationRunfile)
+	require.NoError(t, err)
+	migrationSourceURL := (&url.URL{Scheme: "file", Path: filepath.Dir(firstMigration)}).String()
+	migrator, err := migrate.New(migrationSourceURL, testDatabaseURL.String())
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up())
+	sourceCloseErr, databaseCloseErr := migrator.Close()
+	require.NoError(t, sourceCloseErr)
+	require.NoError(t, databaseCloseErr)
+
+	return testDB
+}
+
+func schemaFingerprint(t *testing.T, db *sql.DB, tables []string) []string {
+	t.Helper()
+
+	rows, err := db.Query(`
+		select concat_ws('|', 'column', table_name, ordinal_position, column_name,
+			data_type, coalesce(character_maximum_length::text, ''), is_nullable,
+			coalesce(column_default, ''))
+		from information_schema.columns
+		where table_schema = current_schema()
+		  and table_name = any($1)
+		union all
+		select concat_ws('|', 'constraint', relation.relname, constraint_name.conname,
+			constraint_name.contype, pg_get_constraintdef(constraint_name.oid, true),
+			constraint_name.convalidated)
+		from pg_constraint as constraint_name
+		join pg_class as relation on relation.oid = constraint_name.conrelid
+		join pg_namespace as namespace on namespace.oid = relation.relnamespace
+		where namespace.nspname = current_schema()
+		  and relation.relname = any($1)
+		union all
+		select concat_ws('|', 'index', tablename, indexname, indexdef)
+		from pg_indexes
+		where schemaname = current_schema()
+		  and tablename = any($1)
+		order by 1
+	`, pq.Array(tables))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var fingerprint []string
+	for rows.Next() {
+		var entry string
+		require.NoError(t, rows.Scan(&entry))
+		fingerprint = append(fingerprint, entry)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, fingerprint, fmt.Sprintf("schema fingerprint for %v", tables))
+	return fingerprint
+}

--- a/services/immersion-api/storage/postgres/models.go
+++ b/services/immersion-api/storage/postgres/models.go
@@ -12,6 +12,20 @@ import (
 	"github.com/google/uuid"
 )
 
+type Announcement struct {
+	ID        uuid.UUID
+	Namespace string
+	Title     string
+	Content   string
+	Style     string
+	Href      sql.NullString
+	StartsAt  time.Time
+	EndsAt    time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt sql.NullTime
+}
+
 type Contest struct {
 	ID                      uuid.UUID
 	OwnerUserID             uuid.UUID
@@ -122,9 +136,47 @@ type ModerationAuditLog struct {
 	CreatedAt   time.Time
 }
 
+type Page struct {
+	ID               uuid.UUID
+	Namespace        string
+	Slug             string
+	CurrentContentID uuid.UUID
+	PublishedAt      sql.NullTime
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	DeletedAt        sql.NullTime
+}
+
+type PagesContent struct {
+	ID        uuid.UUID
+	PageID    uuid.UUID
+	Title     string
+	Html      string
+	CreatedAt time.Time
+}
+
 type PlatformScoringConfig struct {
 	Singleton       bool
 	ActiveRuleSetID uuid.UUID
+}
+
+type Post struct {
+	ID               uuid.UUID
+	Namespace        string
+	Slug             string
+	CurrentContentID uuid.UUID
+	PublishedAt      sql.NullTime
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	DeletedAt        sql.NullTime
+}
+
+type PostsContent struct {
+	ID        uuid.UUID
+	PostID    uuid.UUID
+	Title     string
+	Content   string
+	CreatedAt time.Time
 }
 
 type ScoringRule struct {


### PR DESCRIPTION
## Summary

- add canonical Immersion migration 27 for the final Content tables and indexes
- regenerate the checked-in Immersion sqlc models
- compare the migrated canonical tables against the legacy Content migration chain in PostgreSQL
- keep service DSNs, data, grants, and runtime behavior unchanged

## Sequencing

This is the first standalone migration in database convergence Phase DB-1. It must merge and deploy independently. Confirm production `data.schema_migrations` is clean at version 27 and the five new tables are empty before retargeting or merging the Profile schema PR.

## Validation

- `bazel build //services/...`
- `bazel test //services/...` with PostgreSQL 17
- `bazel run //:gazelle -- -mode=diff`
- `./scripts/generate-sqlc.sh`

**Posted by gpt-5.6-sol**