### PR TITLE
Add Profile schema to the canonical database

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0029_profile_schema.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0029_profile_schema.down.sql
@@ -1,0 +1,6 @@
+begin;
+
+drop table account_deletion_requests;
+drop table profiles;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0029_profile_schema.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0029_profile_schema.up.sql
@@ -1,0 +1,119 @@
+begin;
+
+create table profiles (
+  user_id uuid primary key not null,
+
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now()
+);
+
+create table account_deletion_requests (
+  id uuid primary key default uuid_generate_v4(),
+  identity_id uuid not null unique,
+  status varchar(32) not null,
+  resume_status varchar(32),
+
+  accepted_at timestamp not null,
+  discord_channel_id varchar(32),
+  discord_message_id varchar(32),
+
+  queued_at timestamp,
+  access_locked_at timestamp,
+  immersion_scrubbed_at timestamp,
+  caches_reconciled_at timestamp,
+  authorization_removed_at timestamp,
+  identity_deleted_at timestamp,
+  completed_at timestamp,
+
+  attempt_count integer not null default 0,
+  next_attempt_at timestamp,
+  last_error_code varchar(100),
+  lease_owner uuid,
+  lease_expires_at timestamp,
+  lease_generation bigint not null default 0,
+
+  manual_attention_at timestamp,
+  remediation_due_at timestamp,
+
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+
+  constraint account_deletion_requests_status_valid
+    check (status in (
+      'receipt_pending',
+      'queued',
+      'access_locked',
+      'immersion_scrubbed',
+      'caches_reconciled',
+      'authorization_removed',
+      'identity_deleted',
+      'complete',
+      'manual_attention'
+    )),
+  constraint account_deletion_requests_resume_status_valid
+    check (
+      (
+        status = 'manual_attention'
+        and resume_status in (
+          'queued',
+          'access_locked',
+          'immersion_scrubbed',
+          'caches_reconciled',
+          'authorization_removed',
+          'identity_deleted'
+        )
+      )
+      or (status <> 'manual_attention' and resume_status is null)
+    ),
+  constraint account_deletion_requests_receipt_valid
+    check (
+      status = 'receipt_pending'
+      or (discord_channel_id is not null and discord_message_id is not null)
+    ),
+  constraint account_deletion_requests_receipt_ids_paired
+    check (
+      (discord_channel_id is null and discord_message_id is null)
+      or (discord_channel_id is not null and discord_message_id is not null)
+    ),
+  constraint account_deletion_requests_attempt_count_nonnegative
+    check (attempt_count >= 0),
+  constraint account_deletion_requests_error_code_sanitized
+    check (last_error_code is null or last_error_code ~ '^[a-z0-9_]+$'),
+  constraint account_deletion_requests_lease_paired
+    check (
+      (lease_owner is null and lease_expires_at is null)
+      or (lease_owner is not null and lease_expires_at is not null)
+    ),
+  constraint account_deletion_requests_lease_generation_nonnegative
+    check (lease_generation >= 0),
+  constraint account_deletion_requests_manual_attention_valid
+    check (
+      (
+        status = 'manual_attention'
+        and manual_attention_at is not null
+        and remediation_due_at = manual_attention_at + interval '7 days'
+      )
+      or (
+        status <> 'manual_attention'
+        and manual_attention_at is null
+        and remediation_due_at is null
+      )
+    )
+);
+
+create index account_deletion_requests_worker_claim
+  on account_deletion_requests (next_attempt_at, lease_expires_at, created_at)
+  where status in (
+    'queued',
+    'access_locked',
+    'immersion_scrubbed',
+    'caches_reconciled',
+    'authorization_removed',
+    'identity_deleted'
+  );
+
+create index account_deletion_requests_manual_attention_due
+  on account_deletion_requests (remediation_due_at)
+  where status = 'manual_attention';
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/BUILD.bazel
+++ b/services/immersion-api/storage/postgres/migrations/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     data = [
         ":up_files",
         "//services/content-api/storage/postgres/migrations:up_files",
+        "//services/profile-api/storage/postgres/migrations:up_files",
     ],
     env_inherit = ["IMMERSION_TEST_POSTGRES_URL"],
     deps = [

--- a/services/immersion-api/storage/postgres/migrations/content_schema_convergence_test.go
+++ b/services/immersion-api/storage/postgres/migrations/content_schema_convergence_test.go
@@ -35,7 +35,27 @@ func TestContentSchemaMatchesCanonicalSource(t *testing.T) {
 	var version int
 	var dirty bool
 	require.NoError(t, target.QueryRow("select version, dirty from schema_migrations").Scan(&version, &dirty))
-	require.Equal(t, 28, version)
+	require.Equal(t, 29, version)
+	require.False(t, dirty)
+}
+
+func TestProfileSchemaMatchesCanonicalSource(t *testing.T) {
+	target := openMigratedDatabase(t, "services/immersion-api/storage/postgres/migrations/0001_init.up.sql")
+	source := openMigratedDatabase(t, "services/profile-api/storage/postgres/migrations/0001_init.up.sql")
+	tables := []string{"account_deletion_requests", "profiles"}
+
+	require.Equal(t, schemaFingerprint(t, source, tables), schemaFingerprint(t, target, tables))
+	for _, table := range tables {
+		var count int64
+		err := target.QueryRow("select count(*) from " + pq.QuoteIdentifier(table)).Scan(&count)
+		require.NoError(t, err)
+		require.Zero(t, count, "canonical target table %s must start empty", table)
+	}
+
+	var version int
+	var dirty bool
+	require.NoError(t, target.QueryRow("select version, dirty from schema_migrations").Scan(&version, &dirty))
+	require.Equal(t, 29, version)
 	require.False(t, dirty)
 }
 

--- a/services/immersion-api/storage/postgres/models.go
+++ b/services/immersion-api/storage/postgres/models.go
@@ -12,6 +12,33 @@ import (
 	"github.com/google/uuid"
 )
 
+type AccountDeletionRequest struct {
+	ID                     uuid.UUID
+	IdentityID             uuid.UUID
+	Status                 string
+	ResumeStatus           sql.NullString
+	AcceptedAt             time.Time
+	DiscordChannelID       sql.NullString
+	DiscordMessageID       sql.NullString
+	QueuedAt               sql.NullTime
+	AccessLockedAt         sql.NullTime
+	ImmersionScrubbedAt    sql.NullTime
+	CachesReconciledAt     sql.NullTime
+	AuthorizationRemovedAt sql.NullTime
+	IdentityDeletedAt      sql.NullTime
+	CompletedAt            sql.NullTime
+	AttemptCount           int32
+	NextAttemptAt          sql.NullTime
+	LastErrorCode          sql.NullString
+	LeaseOwner             uuid.NullUUID
+	LeaseExpiresAt         sql.NullTime
+	LeaseGeneration        int64
+	ManualAttentionAt      sql.NullTime
+	RemediationDueAt       sql.NullTime
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+}
+
 type Announcement struct {
 	ID        uuid.UUID
 	Namespace string
@@ -177,6 +204,12 @@ type PostsContent struct {
 	Title     string
 	Content   string
 	CreatedAt time.Time
+}
+
+type Profile struct {
+	UserID    uuid.UUID
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 type ScoringRule struct {

--- a/services/profile-api/storage/postgres/migrations/BUILD.bazel
+++ b/services/profile-api/storage/postgres/migrations/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 filegroup(
     name = "up_files",
     srcs = glob(["*.up.sql"]),
-    visibility = ["//services/profile-api/storage/postgres:__subpackages__"],
+    visibility = [
+        "//services/immersion-api/storage/postgres/migrations:__pkg__",
+        "//services/profile-api/storage/postgres:__subpackages__",
+    ],
 )
 
 pkg_tar(


### PR DESCRIPTION
## Summary

- add standalone canonical migration 29 for the final Profile tables, constraints, and indexes
- regenerate the checked-in Immersion sqlc models
- compare the canonical tables against the legacy Profile migration chain in PostgreSQL
- keep service DSNs, data, grants, and runtime behavior unchanged

## Sequencing gate

Content migration 28 is deployed independently in production: the canonical ledger is clean at 28, all five Content tables are empty, and all four APIs are Ready. This branch is rebased onto that deployed `main` state.

Merge and deploy this PR alone. Before the grants PR advances, confirm a clean ledger at 29, empty `profiles` and `account_deletion_requests` tables, and unchanged API readiness.

## Validation

- `./scripts/generate-sqlc.sh`
- `bazel run //:gazelle -- -mode=diff`
- `bazel build //services/...`
- all 29 `bazel test //services/...` targets against PostgreSQL 17

**Posted by gpt-5.6-sol**