### PR TITLE
Fix reading modifier precedence

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0027_platform_scoring_rule_set_v5_reading_modifier_precedence.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0027_platform_scoring_rule_set_v5_reading_modifier_precedence.down.sql
@@ -1,0 +1,15 @@
+begin;
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 4
+);
+
+delete from scoring_rule_sets
+where scope = 'platform'
+  and version = 5;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0027_platform_scoring_rule_set_v5_reading_modifier_precedence.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0027_platform_scoring_rule_set_v5_reading_modifier_precedence.up.sql
@@ -1,0 +1,66 @@
+begin;
+
+insert into scoring_rule_sets (
+  scope,
+  version,
+  status,
+  published_at
+) values (
+  'platform',
+  5,
+  'published',
+  now()
+);
+
+insert into scoring_rules (
+  rule_set_id,
+  priority,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+) select
+  (
+    select id
+    from scoring_rule_sets
+    where scope = 'platform'
+      and version = 5
+  ),
+  case
+    when activity_id = 1
+      and unit_key = 'reading_page'
+      and tag = 'comic'
+      then 70
+    when activity_id = 1
+      and unit_key = 'reading_page'
+      and tag = 'manga'
+      then 75
+    else priority
+  end,
+  stackable,
+  activity_id,
+  unit_key,
+  language_code,
+  tag,
+  score_source,
+  rate
+from scoring_rules
+where rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 4
+);
+
+update platform_scoring_config
+set active_rule_set_id = (
+  select id
+  from scoring_rule_sets
+  where scope = 'platform'
+    and version = 5
+);
+
+commit;

--- a/services/immersion-api/storage/postgres/repository/repo_findscoringruleset_test.go
+++ b/services/immersion-api/storage/postgres/repository/repo_findscoringruleset_test.go
@@ -20,23 +20,28 @@ func TestActivePlatformScoringRulesSupportReadingPageTags(t *testing.T) {
 	ruleSet, err := repo.FindActivePlatformScoringRuleSet(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, ruleSet)
-	assert.Equal(t, int32(4), ruleSet.Version)
+	assert.Equal(t, int32(5), ruleSet.Version)
 
-	amount := float32(10)
+	amount := float32(200)
 	tests := []struct {
 		name         string
 		unitKey      string
 		languageCode string
 		tags         []string
 		wantScore    float32
+		wantRate     float32
 	}{
-		{name: "ordinary pages", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", wantScore: 10},
-		{name: "Japanese two-column page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"two_column"}, wantScore: 16},
-		{name: "English two-column tag remains informational", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"two_column"}, wantScore: 10},
-		{name: "comic page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"comic"}, wantScore: 2},
-		{name: "manga page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"manga"}, wantScore: 2},
-		{name: "legacy two-column page unit", unitKey: domain.UnitKeyReadingTwoColumnPage, languageCode: "jpn", wantScore: 16},
-		{name: "legacy comic page unit", unitKey: domain.UnitKeyReadingComicPage, languageCode: "eng", wantScore: 2},
+		{name: "ordinary pages", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", wantScore: 200, wantRate: 1},
+		{name: "Japanese two-column page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"two_column"}, wantScore: 320, wantRate: 1.6},
+		{name: "English two-column tag remains informational", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"two_column"}, wantScore: 200, wantRate: 1},
+		{name: "comic page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "eng", tags: []string{"comic"}, wantScore: 40, wantRate: 0.2},
+		{name: "manga page tag", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"manga"}, wantScore: 40, wantRate: 0.2},
+		{name: "comic wins over two-column", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"comic", "two_column"}, wantScore: 40, wantRate: 0.2},
+		{name: "manga wins over two-column", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"manga", "two_column"}, wantScore: 40, wantRate: 0.2},
+		{name: "tag order does not change precedence", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"two_column", "comic"}, wantScore: 40, wantRate: 0.2},
+		{name: "comic and manga win over two-column", unitKey: domain.UnitKeyReadingPage, languageCode: "jpn", tags: []string{"comic", "manga", "two_column"}, wantScore: 40, wantRate: 0.2},
+		{name: "legacy two-column page unit", unitKey: domain.UnitKeyReadingTwoColumnPage, languageCode: "jpn", wantScore: 320, wantRate: 1.6},
+		{name: "legacy comic page unit", unitKey: domain.UnitKeyReadingComicPage, languageCode: "eng", wantScore: 40, wantRate: 0.2},
 	}
 
 	for _, tt := range tests {
@@ -51,6 +56,8 @@ func TestActivePlatformScoringRulesSupportReadingPageTags(t *testing.T) {
 
 			require.NoError(t, evaluateErr)
 			assert.Equal(t, tt.wantScore, result.Score)
+			require.Len(t, result.AppliedRules, 1)
+			assert.InDelta(t, tt.wantRate, result.AppliedRules[0].Rate, 0.0001)
 		})
 	}
 }
@@ -61,7 +68,7 @@ func TestActivePlatformScoringRulesSupportDenseSpeakingDuration(t *testing.T) {
 	ruleSet, err := repo.FindActivePlatformScoringRuleSet(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, ruleSet)
-	assert.Equal(t, int32(4), ruleSet.Version)
+	assert.Equal(t, int32(5), ruleSet.Version)
 
 	durationSeconds := int32(600)
 	tests := []struct {


### PR DESCRIPTION
## Summary

- publish platform scoring rule-set v5
- make comic and manga page rules take precedence over two-column
- add regression coverage for conflicting tags, tag ordering, and applied provenance

## Verification

- regression test reproduced 320 before the migration and returns 40 afterward
- `bazel build //services/...`
- `bazel test //services/...`
- `bazel run //:gazelle -- -mode=diff`

This is a standalone migration change. It does not rewrite historical score snapshots or change evaluator/frontend code.

**Posted by gpt-5.6-sol**