### PR TITLE
Add Tadoku migration and database copy tooling

### DIFF
--- a/scripts/database-provider/BUILD.bazel
+++ b/scripts/database-provider/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_binary(
+    name = "copy-database",
+    srcs = ["copy-database.sh"],
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "copy-database_test",
+    srcs = ["copy-database_test.sh"],
+    args = ["$(rlocationpath :copy-database)"],
+    data = [":copy-database"],
+)

--- a/scripts/database-provider/copy-database.sh
+++ b/scripts/database-provider/copy-database.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+usage() {
+  cat <<'EOF'
+Usage: copy-database.sh <backup.dump>
+
+Required environment:
+  TADOKU_COPY_SOURCE_DSN
+  TADOKU_COPY_TARGET_DSN
+  TADOKU_COPY_EXPECTED_VERSION
+  TADOKU_COPY_WRITES_PAUSED=yes
+
+Optional environment:
+  TADOKU_COPY_SCHEMA                 Application schema (default: data)
+
+The target application schema must be empty and the backup path must not exist.
+The script retains the protected custom-format dump after a transactional restore.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+query() {
+  local dsn="$1"
+  local sql="$2"
+  psql --dbname="$dsn" -X -A -t -v ON_ERROR_STOP=1 -c "$sql"
+}
+
+server_identity() {
+  query "$1" "select current_database() || '|' || coalesce(inet_server_addr()::text, 'local') || '|' || coalesce(inet_server_port()::text, 'local')"
+}
+
+ledger() {
+  query "$1" "select version::text || ':' || dirty::text from ${schema}.schema_migrations"
+}
+
+table_names() {
+  query "$1" "select tablename from pg_tables where schemaname = '${schema}' and tablename <> 'schema_migrations' order by tablename"
+}
+
+fingerprints() {
+  local dsn="$1"
+  local table
+  while IFS= read -r table; do
+    [ -n "$table" ] || continue
+    [[ "$table" =~ ^[a-z_][a-z0-9_]*$ ]] || fail "database contains an unsupported table name: $table"
+    printf '%s|' "$table"
+    query "$dsn" "select count(*)::text || ':' || coalesce(md5(string_agg(md5(to_jsonb(t)::text), '' order by md5(to_jsonb(t)::text))), md5('')) from ${schema}.${table} as t"
+  done < <(table_names "$dsn")
+}
+
+if [ "$#" -ne 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+backup_path="$1"
+source_dsn="${TADOKU_COPY_SOURCE_DSN:-}"
+target_dsn="${TADOKU_COPY_TARGET_DSN:-}"
+expected_version="${TADOKU_COPY_EXPECTED_VERSION:-}"
+schema="${TADOKU_COPY_SCHEMA:-data}"
+
+[ -n "$source_dsn" ] || fail "TADOKU_COPY_SOURCE_DSN is required"
+[ -n "$target_dsn" ] || fail "TADOKU_COPY_TARGET_DSN is required"
+[ "$source_dsn" != "$target_dsn" ] || fail "source and target DSNs must differ"
+[[ "$expected_version" =~ ^[1-9][0-9]*$ ]] || fail "TADOKU_COPY_EXPECTED_VERSION must be a positive integer"
+[ "${TADOKU_COPY_WRITES_PAUSED:-}" = "yes" ] || fail "pause and drain writes, then set TADOKU_COPY_WRITES_PAUSED=yes"
+[[ "$schema" =~ ^[a-z_][a-z0-9_]*$ ]] || fail "TADOKU_COPY_SCHEMA is not a safe PostgreSQL identifier"
+[ ! -e "$backup_path" ] || fail "backup already exists: $backup_path"
+[ -d "$(dirname -- "$backup_path")" ] || fail "backup directory does not exist: $(dirname -- "$backup_path")"
+
+for command in psql pg_dump pg_restore sha256sum cmp; do
+  require_command "$command"
+done
+
+source_identity="$(server_identity "$source_dsn")"
+target_identity="$(server_identity "$target_dsn")"
+[ "$source_identity" != "$target_identity" ] || fail "source and target resolve to the same database"
+
+source_ledger="$(ledger "$source_dsn")"
+[ "$source_ledger" = "${expected_version}:false" ] || \
+  fail "unexpected source migration state (expected ${expected_version}:false, got $source_ledger)"
+
+target_relations="$(query "$target_dsn" "select count(*) from pg_class join pg_namespace on pg_namespace.oid = pg_class.relnamespace where pg_namespace.nspname = '${schema}' and pg_class.relkind in ('r', 'p', 'v', 'm', 'S')")"
+[ "$target_relations" = "0" ] || fail "target schema $schema is not empty"
+
+partial_backup="$(mktemp "${backup_path}.partial.XXXXXX")"
+source_fingerprints="$(mktemp "${TMPDIR:-/tmp}/tadoku-source-fingerprints.XXXXXX")"
+target_fingerprints="$(mktemp "${TMPDIR:-/tmp}/tadoku-target-fingerprints.XXXXXX")"
+cleanup() {
+  rm -f -- "$partial_backup" "$source_fingerprints" "$target_fingerprints"
+}
+trap cleanup EXIT
+
+fingerprints "$source_dsn" >"$source_fingerprints"
+pg_dump --dbname="$source_dsn" --format=custom --no-owner --no-privileges --file="$partial_backup"
+mv -- "$partial_backup" "$backup_path"
+partial_backup=""
+
+pg_restore --dbname="$target_dsn" --exit-on-error --single-transaction --no-owner --no-privileges "$backup_path"
+
+target_ledger="$(ledger "$target_dsn")"
+[ "$target_ledger" = "$source_ledger" ] || \
+  fail "target migration state differs after restore (source $source_ledger, target $target_ledger)"
+
+fingerprints "$target_dsn" >"$target_fingerprints"
+cmp --silent "$source_fingerprints" "$target_fingerprints" || fail "table fingerprints differ after restore"
+
+echo "copied $source_identity to $target_identity"
+echo "migration state: $target_ledger"
+echo "backup: $backup_path"
+echo "backup sha256: $(sha256sum "$backup_path" | cut -d ' ' -f 1)"

--- a/scripts/database-provider/copy-database_test.sh
+++ b/scripts/database-provider/copy-database_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+copy_script="$1"
+if [ ! -x "$copy_script" ]; then
+  copy_script="${RUNFILES_DIR:?}/$copy_script"
+fi
+test_directory="$(mktemp -d)"
+trap 'rm -rf -- "$test_directory"' EXIT
+fake_bin="$test_directory/bin"
+mkdir "$fake_bin"
+
+cat >"$fake_bin/psql" <<'EOF'
+#!/usr/bin/env bash
+dsn=""
+sql=""
+table=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dbname=*) dsn="${1#--dbname=}" ;;
+    -c) shift; sql="$1" ;;
+    -v)
+      shift
+      case "$1" in table=*) table="${1#table=}" ;; esac
+      ;;
+  esac
+  shift
+done
+
+case "$sql" in
+  *current_database*)
+    if [ "${FAKE_SAME_IDENTITY:-}" = yes ]; then echo 'same|10.0.0.1|5432'
+    elif [ "$dsn" = source ]; then echo 'source|10.0.0.1|5432'
+    else echo 'target|10.0.0.2|5432'
+    fi
+    ;;
+  *pg_class*) echo "${FAKE_TARGET_RELATIONS:-0}" ;;
+  *pg_tables*) printf 'logs\nprofiles\n' ;;
+  *schema_migrations*) echo '29:false' ;;
+  *to_jsonb*)
+    if [ "$dsn" = target ] && [ "${FAKE_TARGET_FINGERPRINT_DIFFERENT:-}" = yes ]; then
+      printf '3:%032d\n' "${#table}"
+    else
+      printf '2:%032d\n' "${#table}"
+    fi
+    ;;
+  *) echo "unexpected query: $sql" >&2; exit 1 ;;
+esac
+EOF
+
+cat >"$fake_bin/pg_dump" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  case "$argument" in --file=*) printf 'dump' >"${argument#--file=}" ;; esac
+done
+EOF
+
+cat >"$fake_bin/pg_restore" <<'EOF'
+#!/usr/bin/env bash
+[ -f "${!#}" ]
+EOF
+
+chmod +x "$fake_bin/psql" "$fake_bin/pg_dump" "$fake_bin/pg_restore"
+export PATH="$fake_bin:$PATH"
+export TADOKU_COPY_SOURCE_DSN=source
+export TADOKU_COPY_TARGET_DSN=target
+export TADOKU_COPY_EXPECTED_VERSION=29
+export TADOKU_COPY_WRITES_PAUSED=yes
+
+backup="$test_directory/success.dump"
+"$copy_script" "$backup"
+[ -s "$backup" ]
+[ "$(stat -c %a "$backup")" = 600 ]
+
+if FAKE_SAME_IDENTITY=yes "$copy_script" "$test_directory/same.dump" >"$test_directory/out" 2>&1; then
+  echo "same database was accepted" >&2
+  exit 1
+fi
+grep -q 'source and target resolve to the same database' "$test_directory/out"
+
+if FAKE_TARGET_RELATIONS=1 "$copy_script" "$test_directory/nonempty.dump" >"$test_directory/out" 2>&1; then
+  echo "non-empty target was accepted" >&2
+  exit 1
+fi
+grep -q 'target schema data is not empty' "$test_directory/out"
+
+fingerprint_backup="$test_directory/fingerprint.dump"
+if FAKE_TARGET_FINGERPRINT_DIFFERENT=yes "$copy_script" "$fingerprint_backup" >"$test_directory/out" 2>&1; then
+  echo "different table contents were accepted" >&2
+  exit 1
+fi
+grep -q 'table fingerprints differ after restore' "$test_directory/out"
+[ -s "$fingerprint_backup" ]
+
+if TADOKU_COPY_WRITES_PAUSED=no "$copy_script" "$test_directory/unpaused.dump" >"$test_directory/out" 2>&1; then
+  echo "unpaused writes were accepted" >&2
+  exit 1
+fi
+grep -q 'pause and drain writes' "$test_directory/out"

--- a/services/common/migrate-runner/BUILD.bazel
+++ b/services/common/migrate-runner/BUILD.bazel
@@ -43,5 +43,6 @@ pkg_tar(
         "//services/content-api:__pkg__",
         "//services/immersion-api:__pkg__",
         "//services/profile-api:__pkg__",
+        "//services/tadoku-api/migrations:__pkg__",
     ],
 )

--- a/services/immersion-api/storage/postgres/migrations/BUILD.bazel
+++ b/services/immersion-api/storage/postgres/migrations/BUILD.bazel
@@ -4,7 +4,10 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 filegroup(
     name = "up_files",
     srcs = glob(["*.up.sql"]),
-    visibility = ["//services/immersion-api/storage/postgres/postgrestest:__pkg__"],
+    visibility = [
+        "//services/immersion-api/storage/postgres/postgrestest:__pkg__",
+        "//services/tadoku-api/migrations:__pkg__",
+    ],
 )
 
 pkg_tar(
@@ -12,7 +15,10 @@ pkg_tar(
     srcs = glob(["**/*.sql"]),
     mode = "0644",
     package_dir = "/migrations",
-    visibility = ["//services/immersion-api:__pkg__"],
+    visibility = [
+        "//services/immersion-api:__pkg__",
+        "//services/tadoku-api/migrations:__pkg__",
+    ],
 )
 
 go_test(

--- a/services/tadoku-api/migrations/BUILD.bazel
+++ b/services/tadoku-api/migrations/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_go//go:def.bzl", "go_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+
+alias(
+    name = "canonical_tar",
+    actual = "//services/immersion-api/storage/postgres/migrations:tar",
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_base_linux_amd64",
+    entrypoint = ["/migrate"],
+    tars = [
+        "//services/common/migrate-runner:layer",
+        ":canonical_tar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "migrations_test",
+    srcs = ["migrations_test.go"],
+    data = ["//services/immersion-api/storage/postgres/migrations:up_files"],
+    env_inherit = ["IMMERSION_TEST_POSTGRES_URL"],
+    deps = [
+        "@com_github_golang_migrate_migrate_v4//:migrate",
+        "@com_github_golang_migrate_migrate_v4//database/postgres",
+        "@com_github_golang_migrate_migrate_v4//source/file",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_lib_pq//:pq",
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel",
+    ],
+)

--- a/services/tadoku-api/migrations/migrations_test.go
+++ b/services/tadoku-api/migrations/migrations_test.go
@@ -1,0 +1,73 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalHistoryReachesVersion29AndThenDoesNothing(t *testing.T) {
+	adminURL := os.Getenv("IMMERSION_TEST_POSTGRES_URL")
+	if adminURL == "" {
+		t.Skip("IMMERSION_TEST_POSTGRES_URL is not set; skipping PostgreSQL integration test")
+	}
+
+	parsedAdminURL, err := url.Parse(adminURL)
+	require.NoError(t, err)
+	require.Equal(t, "postgres", parsedAdminURL.Scheme)
+
+	adminDB, err := sql.Open("postgres", adminURL)
+	require.NoError(t, err)
+	require.NoError(t, adminDB.Ping())
+
+	databaseName := "tadoku_migrations_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	_, err = adminDB.Exec(`create database "` + databaseName + `"`)
+	require.NoError(t, err)
+
+	testURL := *parsedAdminURL
+	testURL.Path = "/" + databaseName
+	testDB, err := sql.Open("postgres", testURL.String())
+	require.NoError(t, err)
+	require.NoError(t, testDB.Ping())
+	t.Cleanup(func() {
+		require.NoError(t, testDB.Close())
+		_, dropErr := adminDB.Exec(`drop database "` + databaseName + `" with (force)`)
+		require.NoError(t, dropErr)
+		require.NoError(t, adminDB.Close())
+	})
+
+	firstMigration, err := bazel.Runfile("services/immersion-api/storage/postgres/migrations/0001_init.up.sql")
+	require.NoError(t, err)
+	sourceURL := (&url.URL{Scheme: "file", Path: filepath.Dir(firstMigration)}).String()
+	migrator, err := migrate.New(sourceURL, testURL.String())
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up())
+
+	var version int
+	var dirty bool
+	require.NoError(t, testDB.QueryRow("select version, dirty from schema_migrations").Scan(&version, &dirty))
+	require.Equal(t, 29, version)
+	require.False(t, dirty)
+
+	for _, table := range []string{"logs", "pages", "profiles", "moderation_audit_log"} {
+		var exists bool
+		require.NoError(t, testDB.QueryRow("select to_regclass($1) is not null", table).Scan(&exists))
+		require.True(t, exists, "%s must exist", table)
+	}
+
+	require.ErrorIs(t, migrator.Up(), migrate.ErrNoChange)
+	sourceCloseErr, databaseCloseErr := migrator.Close()
+	require.NoError(t, sourceCloseErr)
+	require.NoError(t, databaseCloseErr)
+}


### PR DESCRIPTION
## Summary

- add a Tadoku-owned migration image that reuses the canonical Immersion migration tar and existing migration runner
- verify empty-to-v29 and converged no-change behavior against real PostgreSQL when configured
- add guarded whole-database dump/restore tooling with write-pause, identity, ledger, and content validation

## Validation

- `bazel test //scripts/database-provider:copy-database_test //services/tadoku-api/migrations:migrations_test --nocache_test_results --test_output=errors`
- `bazel build //services/tadoku-api/migrations:image`
- disposable PostgreSQL 17 empty migration and source-to-target dump/restore rehearsal
- `bazel build //services/...`
- `bazel test //services/... --test_output=errors`

## Scope

This does not switch the live migration executor or mutate provider/production state. The Immersion runner must be disabled before this target is enabled in a separate deployment change.

**Posted by gpt-5.6-sol**