### PR TITLE
Add dark Tadoku API proxy foundation

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -120,6 +120,7 @@ jobs:
             ghcr.io/tadoku/tadoku/image-webhook-gateway:latest
             ghcr.io/tadoku/tadoku/immersion-api:latest
             ghcr.io/tadoku/tadoku/profile-api:latest
+            ghcr.io/tadoku/tadoku/tadoku-api:latest
             ghcr.io/tadoku/tadoku/token-reflector:latest
         run: |
           scan_status=0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ sh_binary(
         "$(rlocationpath //services/image-webhook-gateway:load)",
         "$(rlocationpath //services/immersion-api:load)",
         "$(rlocationpath //services/profile-api:load)",
+        "$(rlocationpath //services/tadoku-api:load)",
         "$(rlocationpath //services/token-reflector:load)",
     ],
     data = [
@@ -26,6 +27,7 @@ sh_binary(
         "//services/image-webhook-gateway:load",
         "//services/immersion-api:load",
         "//services/profile-api:load",
+        "//services/tadoku-api:load",
         "//services/token-reflector:load",
         "@bazel_tools//tools/bash/runfiles",
     ],
@@ -43,6 +45,7 @@ sh_binary(
         "$(rlocationpath //services/image-webhook-gateway:push)",
         "$(rlocationpath //services/immersion-api:push)",
         "$(rlocationpath //services/profile-api:push)",
+        "$(rlocationpath //services/tadoku-api:push)",
         "$(rlocationpath //services/token-reflector:push)",
     ],
     data = [
@@ -51,6 +54,7 @@ sh_binary(
         "//services/image-webhook-gateway:push",
         "//services/immersion-api:push",
         "//services/profile-api:push",
+        "//services/tadoku-api:push",
         "//services/token-reflector:push",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/services/tadoku-api/BUILD.bazel
+++ b/services/tadoku-api/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "app_layer",
+    srcs = ["//services/tadoku-api/cmd/tadoku-api"],
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_base_linux_amd64",
+    entrypoint = ["/tadoku-api"],
+    tars = [":app_layer"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = [
+        "ghcr.io/tadoku/tadoku/tadoku-api:latest",
+        "bazel/services/tadoku-api:latest",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+oci_push(
+    name = "dev_push",
+    image = ":image",
+    visibility = ["//visibility:public"],
+)
+
+oci_push(
+    name = "push",
+    image = ":image",
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
+    repository = "ghcr.io/tadoku/tadoku/tadoku-api",
+    visibility = ["//visibility:public"],
+)

--- a/services/tadoku-api/cmd/tadoku-api/BUILD.bazel
+++ b/services/tadoku-api/cmd/tadoku-api/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "tadoku-api_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/tadoku/tadoku/services/tadoku-api/cmd/tadoku-api",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//services/common/observability",
+        "//services/tadoku-api/transport/http",
+        "@com_github_go_playground_validator_v10//:validator",
+        "@com_github_kelseyhightower_envconfig//:envconfig",
+    ],
+)
+
+go_binary(
+    name = "tadoku-api",
+    embed = [":tadoku-api_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "tadoku-api_test",
+    srcs = ["main_test.go"],
+    embed = [":tadoku-api_lib"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/services/tadoku-api/cmd/tadoku-api/main.go
+++ b/services/tadoku-api/cmd/tadoku-api/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/kelseyhightower/envconfig"
+	commonobservability "github.com/tadoku/tadoku/services/common/observability"
+	transporthttp "github.com/tadoku/tadoku/services/tadoku-api/transport/http"
+)
+
+type config struct {
+	Port                  int           `validate:"gt=0,lte=65535" default:"8000"`
+	MetricsPort           int           `validate:"gt=0,lte=65535" envconfig:"metrics_port" default:"9090"`
+	ServiceName           string        `validate:"required" envconfig:"service_name" default:"tadoku-api"`
+	AuthzURL              string        `validate:"required" envconfig:"authz_url"`
+	ContentURL            string        `validate:"required" envconfig:"content_url"`
+	ImmersionURL          string        `validate:"required" envconfig:"immersion_url"`
+	ProfileURL            string        `validate:"required" envconfig:"profile_url"`
+	DialTimeout           time.Duration `validate:"gt=0" envconfig:"dial_timeout" default:"3s"`
+	ResponseHeaderTimeout time.Duration `validate:"gt=0" envconfig:"response_header_timeout" default:"10s"`
+	RequestTimeout        time.Duration `validate:"gt=0" envconfig:"request_timeout" default:"30s"`
+	IdleTimeout           time.Duration `validate:"gt=0" envconfig:"idle_timeout" default:"30s"`
+	ShutdownTimeout       time.Duration `validate:"gt=0" envconfig:"shutdown_timeout" default:"10s"`
+}
+
+func loadConfig() (config, error) {
+	cfg := config{}
+	if err := envconfig.Process("API", &cfg); err != nil {
+		return config{}, fmt.Errorf("load config: %w", err)
+	}
+	if err := validator.New().Struct(cfg); err != nil {
+		return config{}, fmt.Errorf("validate config: %w", err)
+	}
+	return cfg, nil
+}
+
+type application struct {
+	server          *http.Server
+	listener        net.Listener
+	serverErrors    chan error
+	metricsServer   *commonobservability.Server
+	shutdownTimeout time.Duration
+	transport       *http.Transport
+}
+
+func start(cfg config, logger *slog.Logger) (*application, error) {
+	logger = logger.With("service", cfg.ServiceName)
+	metrics := commonobservability.NewMetrics(nil, cfg.ServiceName)
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: cfg.DialTimeout, KeepAlive: 30 * time.Second}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   25,
+		IdleConnTimeout:       cfg.IdleTimeout,
+		TLSHandshakeTimeout:   cfg.DialTimeout,
+		ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
+		ExpectContinueTimeout: time.Second,
+	}
+	handler, err := transporthttp.NewHandler(transporthttp.Upstreams{
+		Authz: cfg.AuthzURL, Content: cfg.ContentURL,
+		Immersion: cfg.ImmersionURL, Profile: cfg.ProfileURL,
+	}, transport, cfg.RequestTimeout, metrics.Registerer(), logger)
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", cfg.Port))
+	if err != nil {
+		return nil, fmt.Errorf("listen for API requests: %w", err)
+	}
+	metricsServer := commonobservability.NewServer(fmt.Sprintf("0.0.0.0:%d", cfg.MetricsPort), metrics.Handler())
+	if err := metricsServer.Start(); err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("start metrics server: %w", err)
+	}
+
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       cfg.RequestTimeout,
+		WriteTimeout:      cfg.RequestTimeout + time.Second,
+		IdleTimeout:       cfg.IdleTimeout,
+	}
+	app := &application{
+		server: server, listener: listener, serverErrors: make(chan error, 1),
+		metricsServer: metricsServer, shutdownTimeout: cfg.ShutdownTimeout, transport: transport,
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			app.serverErrors <- err
+		}
+	}()
+	logger.Info("tadoku-api started", "address", listener.Addr(), "mode", "proxy")
+	return app, nil
+}
+
+func (app *application) wait(ctx context.Context) error {
+	var runErr error
+	select {
+	case <-ctx.Done():
+	case runErr = <-app.serverErrors:
+		runErr = fmt.Errorf("API server stopped: %w", runErr)
+	case runErr = <-app.metricsServer.Errors():
+		runErr = fmt.Errorf("metrics server stopped: %w", runErr)
+	}
+
+	shutdownContext, cancel := context.WithTimeout(context.Background(), app.shutdownTimeout)
+	defer cancel()
+	app.transport.CloseIdleConnections()
+	return errors.Join(runErr, app.server.Shutdown(shutdownContext), app.metricsServer.Shutdown(shutdownContext))
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg, err := loadConfig()
+	if err != nil {
+		panic(err)
+	}
+	app, err := start(cfg, logger)
+	if err != nil {
+		panic(err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if err := app.wait(ctx); err != nil {
+		panic(err)
+	}
+}

--- a/services/tadoku-api/cmd/tadoku-api/main_test.go
+++ b/services/tadoku-api/cmd/tadoku-api/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplicationStartsAndShutsDown(t *testing.T) {
+	upstream := httptest.NewServer(http.NotFoundHandler())
+	defer upstream.Close()
+	cfg := config{
+		Port: 0, MetricsPort: 0, ServiceName: "tadoku-api-test",
+		AuthzURL: upstream.URL, ContentURL: upstream.URL, ImmersionURL: upstream.URL, ProfileURL: upstream.URL,
+		DialTimeout: time.Second, ResponseHeaderTimeout: time.Second, RequestTimeout: time.Second,
+		IdleTimeout: time.Second, ShutdownTimeout: time.Second,
+	}
+	app, err := start(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+
+	_, port, err := net.SplitHostPort(app.listener.Addr().String())
+	require.NoError(t, err)
+	address := net.JoinHostPort("127.0.0.1", port)
+	response, err := http.Get("http://" + address + "/readyz")
+	require.NoError(t, err)
+	defer response.Body.Close()
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, app.wait(ctx))
+
+	_, err = http.Get("http://" + address + "/livez")
+	assert.Error(t, err)
+}
+
+func TestLoadConfigUsesValidatedDefaults(t *testing.T) {
+	t.Setenv("API_AUTHZ_URL", "http://authz")
+	t.Setenv("API_CONTENT_URL", "http://content")
+	t.Setenv("API_IMMERSION_URL", "http://immersion")
+	t.Setenv("API_PROFILE_URL", "http://profile")
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 8000, cfg.Port)
+	assert.Equal(t, 9090, cfg.MetricsPort)
+	assert.Equal(t, "tadoku-api", cfg.ServiceName)
+	assert.Equal(t, 30*time.Second, cfg.RequestTimeout)
+}

--- a/services/tadoku-api/deployments/api.yaml
+++ b/services/tadoku-api/deployments/api.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tdk-tadoku-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tadoku-api
+  namespace: tdk-tadoku-api
+  labels:
+    app: tadoku-api
+spec:
+  selector:
+    matchLabels:
+      app: tadoku-api
+  template:
+    metadata:
+      labels:
+        app: tadoku-api
+    spec:
+      containers:
+        - name: tadoku-api
+          image: tadoku-api-image
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: metrics
+              containerPort: 9090
+          env:
+            - {name: API_PORT, value: "8000"}
+            - {name: API_METRICS_PORT, value: "9090"}
+            - {name: API_SERVICE_NAME, value: tadoku-api}
+            - {name: API_AUTHZ_URL, value: "http://authz-api.tdk-authz-api"}
+            - {name: API_CONTENT_URL, value: "http://content-api.tdk-content-api"}
+            - {name: API_IMMERSION_URL, value: "http://immersion-api.tdk-immersion-api"}
+            - {name: API_PROFILE_URL, value: "http://profile-api.tdk-profile-api"}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tadoku-api
+  namespace: tdk-tadoku-api
+  labels:
+    app: tadoku-api
+    service: tadoku-api
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+  selector:
+    app: tadoku-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tadoku-api-metrics
+  namespace: tdk-tadoku-api
+  labels:
+    app: tadoku-api
+    service: tadoku-api-metrics
+spec:
+  ports:
+    - port: 9090
+      targetPort: metrics
+      name: metrics
+  selector:
+    app: tadoku-api

--- a/services/tadoku-api/transport/http/BUILD.bazel
+++ b/services/tadoku-api/transport/http/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "http",
+    srcs = ["proxy.go"],
+    importpath = "github.com/tadoku/tadoku/services/tadoku-api/transport/http",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_prometheus_client_golang//prometheus"],
+)
+
+go_test(
+    name = "http_test",
+    srcs = ["proxy_test.go"],
+    embed = [":http"],
+    deps = [
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/services/tadoku-api/transport/http/proxy.go
+++ b/services/tadoku-api/transport/http/proxy.go
@@ -1,0 +1,202 @@
+package http
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const correlationHeader = "X-Request-Id"
+
+type Upstreams struct {
+	Authz     string
+	Content   string
+	Immersion string
+	Profile   string
+}
+
+type route struct {
+	name   string
+	prefix string
+	target string
+}
+
+func NewHandler(upstreams Upstreams, transport stdhttp.RoundTripper, requestTimeout time.Duration, registerer prometheus.Registerer, logger *slog.Logger) (stdhttp.Handler, error) {
+	if requestTimeout <= 0 {
+		return nil, fmt.Errorf("request timeout must be positive")
+	}
+	if transport == nil {
+		return nil, fmt.Errorf("transport is required")
+	}
+	if registerer == nil {
+		return nil, fmt.Errorf("metrics registerer is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	duration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "tadoku_api_proxy_request_duration_seconds",
+		Help: "Duration of requests proxied to legacy APIs.",
+	}, []string{"route", "upstream", "mode", "status"})
+	if err := registerer.Register(duration); err != nil {
+		return nil, fmt.Errorf("register proxy metrics: %w", err)
+	}
+
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("GET /livez", func(response stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_, _ = response.Write([]byte("ok"))
+	})
+	mux.HandleFunc("GET /readyz", func(response stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"status":"ready","checks":[]}`))
+	})
+
+	routes := []route{
+		{name: "authz", prefix: "/api/internal/authz/", target: upstreams.Authz},
+		{name: "content", prefix: "/api/internal/content/", target: upstreams.Content},
+		{name: "immersion", prefix: "/api/internal/immersion/", target: upstreams.Immersion},
+		{name: "profile", prefix: "/api/internal/profile/", target: upstreams.Profile},
+	}
+	for _, current := range routes {
+		target, err := parseTarget(current.target)
+		if err != nil {
+			return nil, fmt.Errorf("%s upstream: %w", current.name, err)
+		}
+		mux.Handle(current.prefix, observe(current, requestTimeout, newReverseProxy(current, target, transport, logger), duration, logger))
+	}
+
+	return mux, nil
+}
+
+func parseTarget(raw string) (*url.URL, error) {
+	target, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if (target.Scheme != "http" && target.Scheme != "https") || target.Host == "" {
+		return nil, fmt.Errorf("must be an absolute http or https URL")
+	}
+	if target.User != nil || (target.Path != "" && target.Path != "/") || target.RawQuery != "" || target.Fragment != "" {
+		return nil, fmt.Errorf("must not contain credentials, a path, query, or fragment")
+	}
+	return target, nil
+}
+
+func newReverseProxy(current route, target *url.URL, transport stdhttp.RoundTripper, logger *slog.Logger) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Transport: transport,
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(target)
+			request.Out.Host = request.In.Host
+			request.SetXForwarded()
+			request.Out.URL.Path = "/" + strings.TrimPrefix(request.In.URL.Path, current.prefix)
+			request.Out.URL.RawPath = "/" + strings.TrimPrefix(request.In.URL.EscapedPath(), current.prefix)
+			if request.Out.URL.RawPath == request.Out.URL.Path {
+				request.Out.URL.RawPath = ""
+			}
+		},
+		ModifyResponse: func(response *stdhttp.Response) error {
+			response.Header.Set(correlationHeader, correlationID(response.Request))
+			return nil
+		},
+		ErrorHandler: func(response stdhttp.ResponseWriter, request *stdhttp.Request, err error) {
+			status := stdhttp.StatusBadGateway
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(request.Context().Err(), context.DeadlineExceeded) {
+				status = stdhttp.StatusGatewayTimeout
+			}
+			logger.WarnContext(request.Context(), "proxy request failed",
+				"correlation_id", correlationID(request),
+				"upstream", current.name,
+				"error", err,
+			)
+			stdhttp.Error(response, stdhttp.StatusText(status), status)
+		},
+	}
+}
+
+func observe(current route, timeout time.Duration, next stdhttp.Handler, duration *prometheus.HistogramVec, logger *slog.Logger) stdhttp.Handler {
+	return stdhttp.HandlerFunc(func(response stdhttp.ResponseWriter, request *stdhttp.Request) {
+		started := time.Now()
+		ctx, cancel := context.WithTimeout(request.Context(), timeout)
+		defer cancel()
+
+		request = request.WithContext(withCorrelationID(ctx, request.Header.Get(correlationHeader)))
+		request.Header.Set(correlationHeader, correlationID(request))
+		response.Header().Set(correlationHeader, correlationID(request))
+		recorder := &statusRecorder{ResponseWriter: response}
+		next.ServeHTTP(recorder, request)
+
+		status := recorder.status
+		if status == 0 {
+			status = stdhttp.StatusOK
+		}
+		elapsed := time.Since(started)
+		duration.WithLabelValues(current.prefix, current.name, "proxy", strconv.Itoa(status)).Observe(elapsed.Seconds())
+		logger.InfoContext(request.Context(), "request completed",
+			"correlation_id", correlationID(request),
+			"method", request.Method,
+			"route", current.prefix,
+			"upstream", current.name,
+			"mode", "proxy",
+			"status", status,
+			"latency", elapsed,
+		)
+	})
+}
+
+type statusRecorder struct {
+	stdhttp.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	if status >= 100 && status < 200 {
+		r.ResponseWriter.WriteHeader(status)
+		return
+	}
+	if r.status != 0 {
+		return
+	}
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(body []byte) (int, error) {
+	if r.status == 0 {
+		r.WriteHeader(stdhttp.StatusOK)
+	}
+	return r.ResponseWriter.Write(body)
+}
+
+func (r *statusRecorder) Unwrap() stdhttp.ResponseWriter { return r.ResponseWriter }
+
+type correlationIDKey struct{}
+
+func withCorrelationID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		var value [16]byte
+		if _, err := rand.Read(value[:]); err == nil {
+			id = hex.EncodeToString(value[:])
+		} else {
+			id = "unavailable"
+		}
+	}
+	return context.WithValue(ctx, correlationIDKey{}, id)
+}
+
+func correlationID(request *stdhttp.Request) string {
+	id, _ := request.Context().Value(correlationIDKey{}).(string)
+	return id
+}

--- a/services/tadoku-api/transport/http/proxy_test.go
+++ b/services/tadoku-api/transport/http/proxy_test.go
@@ -1,0 +1,282 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type receivedRequest struct {
+	method        string
+	path          string
+	rawQuery      string
+	body          string
+	authorization string
+	correlationID string
+	host          string
+}
+
+func TestHandlerProxiesEachLegacyPrefix(t *testing.T) {
+	received := make(map[string]chan receivedRequest)
+	servers := make(map[string]*httptest.Server)
+	for _, name := range []string{"authz", "content", "immersion", "profile"} {
+		name := name
+		received[name] = make(chan receivedRequest, 1)
+		servers[name] = httptest.NewServer(stdhttp.HandlerFunc(func(response stdhttp.ResponseWriter, request *stdhttp.Request) {
+			body, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+			received[name] <- receivedRequest{
+				method:        request.Method,
+				path:          request.URL.EscapedPath(),
+				rawQuery:      request.URL.RawQuery,
+				body:          string(body),
+				authorization: request.Header.Get("Authorization"),
+				correlationID: request.Header.Get(correlationHeader),
+				host:          request.Host,
+			}
+			response.Header().Set("X-Legacy-Upstream", name)
+			response.WriteHeader(stdhttp.StatusAccepted)
+			_, _ = response.Write([]byte("from-" + name))
+		}))
+		defer servers[name].Close()
+	}
+
+	var logs bytes.Buffer
+	registry := prometheus.NewRegistry()
+	handler, err := NewHandler(Upstreams{
+		Authz: servers["authz"].URL, Content: servers["content"].URL,
+		Immersion: servers["immersion"].URL, Profile: servers["profile"].URL,
+	}, stdhttp.DefaultTransport, time.Second, registry, slog.New(slog.NewJSONHandler(&logs, nil)))
+	require.NoError(t, err)
+	facade := httptest.NewServer(handler)
+	defer facade.Close()
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		wantPath string
+		body     string
+	}{
+		{name: "authz", method: stdhttp.MethodGet, path: "/api/internal/authz/ping?detail=full", wantPath: "/ping"},
+		{name: "content", method: stdhttp.MethodPost, path: "/api/internal/content/pages/blog", wantPath: "/pages/blog", body: `{"title":"hello"}`},
+		{name: "immersion", method: stdhttp.MethodPatch, path: "/api/internal/immersion/logs/a%2Fb", wantPath: "/logs/a%2Fb", body: `{"amount":10}`},
+		{name: "profile", method: stdhttp.MethodDelete, path: "/api/internal/profile/users/old", wantPath: "/users/old"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := stdhttp.NewRequest(test.method, facade.URL+test.path, bytes.NewBufferString(test.body))
+			require.NoError(t, err)
+			request.Host = "app.tadoku.test"
+			request.Header.Set("Authorization", "Bearer oathkeeper-identity")
+			request.Header.Set(correlationHeader, "request-"+test.name)
+
+			response, err := facade.Client().Do(request)
+			require.NoError(t, err)
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, stdhttp.StatusAccepted, response.StatusCode)
+			assert.Equal(t, "from-"+test.name, string(body))
+			assert.Equal(t, test.name, response.Header.Get("X-Legacy-Upstream"))
+			assert.Equal(t, "request-"+test.name, response.Header.Get(correlationHeader))
+
+			var got receivedRequest
+			select {
+			case got = <-received[test.name]:
+			case <-time.After(time.Second):
+				require.Fail(t, "request did not reach expected upstream")
+			}
+			assert.Equal(t, test.method, got.method)
+			assert.Equal(t, test.body, got.body)
+			assert.Equal(t, "Bearer oathkeeper-identity", got.authorization)
+			assert.Equal(t, "request-"+test.name, got.correlationID)
+			assert.Equal(t, "app.tadoku.test", got.host)
+			assert.Equal(t, test.wantPath, got.path)
+			if test.name == "authz" {
+				assert.Equal(t, "detail=full", got.rawQuery)
+			}
+		})
+	}
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	metricNames := make([]string, 0, len(metricFamilies))
+	for _, family := range metricFamilies {
+		metricNames = append(metricNames, family.GetName())
+	}
+	assert.Contains(t, metricNames, "tadoku_api_proxy_request_duration_seconds")
+	for _, test := range tests {
+		assert.Contains(t, logs.String(), `"correlation_id":"request-`+test.name+`"`)
+		assert.Contains(t, logs.String(), `"upstream":"`+test.name+`"`)
+	}
+}
+
+func TestHandlerGeneratesAndForwardsCorrelationID(t *testing.T) {
+	receivedID := make(chan string, 1)
+	upstream := httptest.NewServer(stdhttp.HandlerFunc(func(response stdhttp.ResponseWriter, request *stdhttp.Request) {
+		receivedID <- request.Header.Get(correlationHeader)
+		response.WriteHeader(stdhttp.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	var logs bytes.Buffer
+	handler, err := NewHandler(Upstreams{
+		Authz: upstream.URL, Content: upstream.URL, Immersion: upstream.URL, Profile: upstream.URL,
+	}, stdhttp.DefaultTransport, time.Second, prometheus.NewRegistry(), slog.New(slog.NewJSONHandler(&logs, nil)))
+	require.NoError(t, err)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(stdhttp.MethodGet, "/api/internal/content/ping", nil))
+
+	generatedID := response.Header().Get(correlationHeader)
+	assert.NotEmpty(t, generatedID)
+	assert.Equal(t, generatedID, <-receivedID)
+	assert.Contains(t, logs.String(), `"correlation_id":"`+generatedID+`"`)
+}
+
+func TestHandlerReturnsBadGatewayWhenUpstreamIsUnavailable(t *testing.T) {
+	upstream := httptest.NewServer(stdhttp.NotFoundHandler())
+	url := upstream.URL
+	upstream.Close()
+
+	handler := newTestHandler(t, url, time.Second)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(stdhttp.MethodGet, "/api/internal/authz/ping", nil))
+
+	assert.Equal(t, stdhttp.StatusBadGateway, response.Code)
+	assert.Equal(t, "Bad Gateway\n", response.Body.String())
+	assert.NotEmpty(t, response.Header().Get(correlationHeader))
+}
+
+func TestHandlerTimesOutAndCancelsUpstreamRequest(t *testing.T) {
+	cancelled := make(chan struct{})
+	transport := roundTripFunc(func(request *stdhttp.Request) (*stdhttp.Response, error) {
+		<-request.Context().Done()
+		close(cancelled)
+		return nil, request.Context().Err()
+	})
+
+	handler := newTestHandlerWithTransport(t, transport, 20*time.Millisecond)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(stdhttp.MethodPost, "/api/internal/immersion/logs", bytes.NewBufferString("body")))
+
+	assert.Equal(t, stdhttp.StatusGatewayTimeout, response.Code)
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		require.Fail(t, "upstream request was not cancelled")
+	}
+}
+
+func TestHandlerHealthAndUnknownRoutes(t *testing.T) {
+	handler := newTestHandler(t, "http://127.0.0.1:1", time.Second)
+
+	for _, test := range []struct {
+		path   string
+		status int
+		body   string
+	}{
+		{path: "/livez", status: stdhttp.StatusOK, body: "ok"},
+		{path: "/readyz", status: stdhttp.StatusOK, body: `{"status":"ready","checks":[]}`},
+		{path: "/internal/v1/ping", status: stdhttp.StatusNotFound, body: "404 page not found\n"},
+	} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(stdhttp.MethodGet, test.path, nil))
+		assert.Equal(t, test.status, response.Code)
+		assert.Equal(t, test.body, response.Body.String())
+	}
+}
+
+func TestNewHandlerRejectsInvalidConfiguration(t *testing.T) {
+	valid := Upstreams{
+		Authz: "http://authz", Content: "http://content",
+		Immersion: "http://immersion", Profile: "http://profile",
+	}
+
+	tests := []struct {
+		name      string
+		upstreams Upstreams
+		timeout   time.Duration
+	}{
+		{name: "missing upstream", upstreams: Upstreams{}, timeout: time.Second},
+		{name: "upstream path", upstreams: Upstreams{Authz: "http://authz/base", Content: valid.Content, Immersion: valid.Immersion, Profile: valid.Profile}, timeout: time.Second},
+		{name: "timeout", upstreams: valid},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewHandler(test.upstreams, stdhttp.DefaultTransport, test.timeout, prometheus.NewRegistry(), slog.Default())
+			assert.Error(t, err)
+		})
+	}
+}
+
+func newTestHandler(t *testing.T, upstream string, timeout time.Duration) stdhttp.Handler {
+	t.Helper()
+	handler, err := NewHandler(Upstreams{
+		Authz: upstream, Content: upstream, Immersion: upstream, Profile: upstream,
+	}, stdhttp.DefaultTransport, timeout, prometheus.NewRegistry(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	return handler
+}
+
+func newTestHandlerWithTransport(t *testing.T, transport stdhttp.RoundTripper, timeout time.Duration) stdhttp.Handler {
+	t.Helper()
+	handler, err := NewHandler(Upstreams{
+		Authz: "http://authz", Content: "http://content", Immersion: "http://immersion", Profile: "http://profile",
+	}, transport, timeout, prometheus.NewRegistry(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	return handler
+}
+
+type roundTripFunc func(*stdhttp.Request) (*stdhttp.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *stdhttp.Request) (*stdhttp.Response, error) {
+	return fn(request)
+}
+
+func TestRequestCancellationIsPreserved(t *testing.T) {
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	transport := roundTripFunc(func(request *stdhttp.Request) (*stdhttp.Response, error) {
+		close(started)
+		<-request.Context().Done()
+		close(cancelled)
+		return nil, request.Context().Err()
+	})
+
+	handler := newTestHandlerWithTransport(t, transport, time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	request := httptest.NewRequest(stdhttp.MethodGet, "/api/internal/profile/users", nil).WithContext(ctx)
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(httptest.NewRecorder(), request)
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.Fail(t, "request did not reach upstream")
+	}
+	cancel()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		require.Fail(t, "upstream request was not cancelled")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.Fail(t, "proxy did not return after cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- add the minimal `tadoku-api` process with configuration, health/readiness, metrics, structured logging, and graceful shutdown
- proxy four explicit Authz, Content, Immersion, and Profile prefixes using the standard library
- preserve request/response protocol behavior, identity, correlation, cancellation, escaped paths, and bounded failure handling
- add an image and non-routed deployment manifest without changing Tilt or Oathkeeper

## Validation

- `bazel test //services/tadoku-api/... --nocache_test_results --test_output=errors`
- `bazel build //services/tadoku-api/...`
- `bazel build //services/...`
- `bazel test //services/... --test_output=errors`

## Scope

The service remains dark and contains no native business behavior, repositories, SQL, or migration credentials. External contract and latency testing remains required before any facade-routing change.

**Posted by gpt-5.6-sol**