### PR TITLE
Publish and adopt the Tadoku migration runner

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Check load_images covers all production oci_load targets
         run: |
           diff \
-            <(bazel query --lockfile_mode=error 'filter("^//services/[^/]+:load$", attr(name, "^load$", kind("oci_load", //services/...)))' | sort) \
+            <(bazel query --lockfile_mode=error 'attr(name, "^load$", kind("oci_load", //services/...))' | sort) \
             <(bazel query --lockfile_mode=error 'kind("oci_load", labels(data, //:load_images))' | sort) \
           || { echo "//:load_images is out of sync with production oci_load targets named :load under //services/..." >&2; exit 1; }
 
@@ -121,6 +121,7 @@ jobs:
             ghcr.io/tadoku/tadoku/immersion-api:latest
             ghcr.io/tadoku/tadoku/profile-api:latest
             ghcr.io/tadoku/tadoku/tadoku-api:latest
+            ghcr.io/tadoku/tadoku/tadoku-api-migrations:latest
             ghcr.io/tadoku/tadoku/token-reflector:latest
         run: |
           scan_status=0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ sh_binary(
         "$(rlocationpath //services/immersion-api:load)",
         "$(rlocationpath //services/profile-api:load)",
         "$(rlocationpath //services/tadoku-api:load)",
+        "$(rlocationpath //services/tadoku-api/migrations:load)",
         "$(rlocationpath //services/token-reflector:load)",
     ],
     data = [
@@ -28,6 +29,7 @@ sh_binary(
         "//services/immersion-api:load",
         "//services/profile-api:load",
         "//services/tadoku-api:load",
+        "//services/tadoku-api/migrations:load",
         "//services/token-reflector:load",
         "@bazel_tools//tools/bash/runfiles",
     ],
@@ -46,6 +48,7 @@ sh_binary(
         "$(rlocationpath //services/immersion-api:push)",
         "$(rlocationpath //services/profile-api:push)",
         "$(rlocationpath //services/tadoku-api:push)",
+        "$(rlocationpath //services/tadoku-api/migrations:push)",
         "$(rlocationpath //services/token-reflector:push)",
     ],
     data = [
@@ -55,6 +58,7 @@ sh_binary(
         "//services/immersion-api:push",
         "//services/profile-api:push",
         "//services/tadoku-api:push",
+        "//services/tadoku-api/migrations:push",
         "//services/token-reflector:push",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/services/immersion-api/Tiltfile
+++ b/services/immersion-api/Tiltfile
@@ -10,6 +10,16 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
+bazel_build(
+  'tadoku-api-migrations-image',
+  '//services/tadoku-api/migrations:load',
+  deps=[
+    './../common/migrate-runner/',
+    './storage/postgres/migrations/',
+    './../tadoku-api/migrations/',
+  ],
+)
+
 k8s_resource(
   'immersion-api',
   labels=["backend"],

--- a/services/immersion-api/deployments/api.yaml
+++ b/services/immersion-api/deployments/api.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       serviceAccountName: immersion-api
       initContainers:
-        - name: migrations
-          image: immersion-api-image
+        - name: tadoku-migrations
+          image: tadoku-api-migrations-image
           imagePullPolicy: IfNotPresent
           command: ['/migrate']
           args: ['-source', 'file:///migrations', 'up']

--- a/services/tadoku-api/migrations/BUILD.bazel
+++ b/services/tadoku-api/migrations/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_go//go:def.bzl", "go_test")
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 
 alias(
     name = "canonical_tar",
@@ -14,6 +14,33 @@ oci_image(
         "//services/common/migrate-runner:layer",
         ":canonical_tar",
     ],
+    visibility = ["//visibility:public"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = [
+        "ghcr.io/tadoku/tadoku/tadoku-api-migrations:latest",
+        "bazel/services/tadoku-api/migrations:latest",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+oci_push(
+    name = "dev_push",
+    image = ":image",
+    visibility = ["//visibility:public"],
+)
+
+oci_push(
+    name = "push",
+    image = ":image",
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
+    repository = "ghcr.io/tadoku/tadoku/tadoku-api-migrations",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Summary

- publish the dedicated `tadoku-api-migrations` image through the existing Bazel image pipeline
- load and vulnerability-scan the migration image alongside other production images
- atomically replace the dev Immersion migration init image with the Tadoku-owned runner
- leave the Immersion application image, database connection, and all Oathkeeper routes unchanged

## Why this is separate

This is the schema-neutral executor handoff after #848. A new pod has only one configured migration init container, so the old and new executors cannot race. It does not depend on the dark Tadoku API in #849.

## Validation

- `bazel run //:gazelle`
- production `oci_push` and `oci_load` aggregate coverage queries match
- `bazel build //...`
- `bazel test //... --test_output=errors`

## Scope

This does not switch a production database, change application DSNs, or perform the PlanetScale copy. Production deployment configuration must make the same executor substitution before the provider cutover.

**Posted by gpt-5.6-sol**