### PR TITLE
Scope PlanetScale copy to the canonical schema

### DIFF
--- a/scripts/database-provider/copy-database.sh
+++ b/scripts/database-provider/copy-database.sh
@@ -103,7 +103,14 @@ cleanup() {
 trap cleanup EXIT
 
 fingerprints "$source_dsn" >"$source_fingerprints"
-pg_dump --dbname="$source_dsn" --format=custom --no-owner --no-privileges --file="$partial_backup"
+pg_dump \
+  --dbname="$source_dsn" \
+  --format=custom \
+  --no-owner \
+  --no-privileges \
+  --schema="$schema" \
+  --extension=uuid-ossp \
+  --file="$partial_backup"
 mv -- "$partial_backup" "$backup_path"
 partial_backup=""
 

--- a/scripts/database-provider/copy-database_test.sh
+++ b/scripts/database-provider/copy-database_test.sh
@@ -51,6 +51,19 @@ EOF
 
 cat >"$fake_bin/pg_dump" <<'EOF'
 #!/usr/bin/env bash
+for required_argument in --schema=data --extension=uuid-ossp; do
+  found=no
+  for argument in "$@"; do
+    if [ "$argument" = "$required_argument" ]; then
+      found=yes
+      break
+    fi
+  done
+  [ "$found" = yes ] || {
+    echo "missing dump scope: $required_argument" >&2
+    exit 1
+  }
+done
 for argument in "$@"; do
   case "$argument" in --file=*) printf 'dump' >"${argument#--file=}" ;; esac
 done


### PR DESCRIPTION
## Summary

- dump only the canonical application schema and its required `uuid-ossp` extension
- exclude the retained `old` schema and source-cluster observability extensions by construction
- cover the dump scope in the provider copy test

## Evidence

A PostgreSQL 17 schema-only dump was exercised against the live PostgreSQL 14 source using the production owner role. The resulting archive contains `data` and `uuid-ossp` only.

## Validation

- `bazel run //:gazelle -- -mode=diff`
- `bazel build //...`
- `bazel test //... --test_output=errors`

**Posted by gpt-5.6-sol**