### PR TITLE
Add a visible Log activity button to the header

### DIFF
--- a/frontend/apps/webv2/app/feature-flags/client.test.tsx
+++ b/frontend/apps/webv2/app/feature-flags/client.test.tsx
@@ -225,7 +225,9 @@ describe('feature flag browser state', () => {
     fireEvent.change(input, { target: { value: 'unsaved form value' } })
 
     act(() => routerEvents.emit())
-    await act(() => vi.advanceTimersByTimeAsync(50))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50)
+    })
 
     expect(screen.getByText('disabled')).toBeTruthy()
     expect(input.value).toBe('unsaved form value')

--- a/frontend/apps/webv2/app/ui/Navigation.test.tsx
+++ b/frontend/apps/webv2/app/ui/Navigation.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Navigation from './Navigation'
+
+Reflect.set(globalThis, 'React', React)
+
+const state = vi.hoisted(() => ({
+  signedIn: true,
+  role: 'user',
+  pathname: '/',
+  navigate: vi.fn(),
+}))
+
+vi.mock('@app/common/session', () => ({
+  useSession: () => [
+    state.signedIn
+      ? { identity: { id: 'reader', traits: { display_name: 'Reader' } } }
+      : undefined,
+  ],
+  useUserRole: () => state.role,
+  useLogoutHandler: () => vi.fn(),
+}))
+vi.mock('@app/common/hooks', () => ({ useCurrentLocation: () => '/' }))
+vi.mock('react-query', () => ({ useIsFetching: () => 0 }))
+vi.mock('next/config', () => ({
+  default: () => ({ publicRuntimeConfig: { authUiUrl: '/account' } }),
+}))
+vi.mock('ui/node_modules/next/router', () => ({
+  useRouter: () => ({ pathname: state.pathname }),
+}))
+vi.mock('ui/node_modules/next/link', () => ({
+  default: React.forwardRef<HTMLAnchorElement, React.ComponentProps<'a'>>(
+    function Link({ onClick, ...props }, ref) {
+      return (
+        <a
+          {...props}
+          ref={ref}
+          onClick={event => {
+            onClick?.(event)
+            if (!event.defaultPrevented) state.navigate(props.href)
+            event.preventDefault()
+          }}
+        />
+      )
+    },
+  ),
+}))
+vi.mock('ui/components/branding', () => ({ Logo: () => <span>Tadoku</span> }))
+
+beforeEach(() => {
+  state.signedIn = true
+  state.role = 'user'
+  state.pathname = '/'
+  state.navigate.mockClear()
+  vi.stubGlobal('scrollTo', vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('New log header action', () => {
+  it('links directly to New log for signed-in readers', () => {
+    render(<Navigation />)
+    // JSDOM has no Tailwind layout: desktop and mobile copies are both present.
+    const actions = screen.getAllByRole('link', { name: 'New log' })
+    expect(actions).toHaveLength(2)
+    for (const action of actions) {
+      expect(action.getAttribute('href')).toBe('/logs/new')
+    }
+    fireEvent.click(actions[0])
+    expect(state.navigate).toHaveBeenCalledWith('/logs/new')
+  })
+
+  it.each(['user', 'admin'])(
+    'hides the mobile action while the %s menu is open',
+    async role => {
+      state.role = role
+      render(<Navigation />)
+      fireEvent.click(screen.getByRole('button', { name: 'Open main menu' }))
+
+      await waitFor(() => {
+        // Only the desktop copy remains; there is no duplicate in the drawer.
+        expect(screen.getAllByRole('link', { name: 'New log' })).toHaveLength(1)
+        expect(
+          screen.getByRole('button', { name: 'Close main menu' }),
+        ).toBeTruthy()
+      })
+      expect(screen.getByRole('link', { name: 'Profile' })).toBeTruthy()
+      fireEvent.click(screen.getByRole('button', { name: 'Close main menu' }))
+      await waitFor(() =>
+        expect(screen.getAllByRole('link', { name: 'New log' })).toHaveLength(
+          2,
+        ),
+      )
+    },
+  )
+
+  it('does not expose New log when signed out', () => {
+    state.signedIn = false
+    render(<Navigation />)
+    expect(screen.queryByRole('link', { name: 'New log' })).toBeNull()
+    expect(screen.getByRole('link', { name: 'Log in' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Sign up' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Open main menu' }))
+    expect(screen.queryByRole('link', { name: 'New log' })).toBeNull()
+  })
+
+  it('does not navigate away from an in-progress New log form', () => {
+    state.pathname = '/logs/new'
+    render(<Navigation />)
+    const action = screen.getAllByRole('link', { name: 'New log' })[0]
+    expect(action.getAttribute('aria-current')).toBe('page')
+    fireEvent.click(action)
+    expect(state.navigate).not.toHaveBeenCalled()
+
+    // Opening a separate tab remains possible.
+    fireEvent.click(action, { ctrlKey: true })
+    expect(state.navigate).toHaveBeenCalledWith('/logs/new')
+  })
+})

--- a/frontend/apps/webv2/app/ui/Navigation.test.tsx
+++ b/frontend/apps/webv2/app/ui/Navigation.test.tsx
@@ -73,10 +73,12 @@ describe('New log header action', () => {
   it('links directly to New log for signed-in readers', () => {
     render(<Navigation />)
     // JSDOM has no Tailwind layout: desktop and mobile copies are both present.
-    const actions = screen.getAllByRole('link', { name: 'New log' })
+    const actions = screen.getAllByRole('link', { name: 'Log activity' })
     expect(actions).toHaveLength(2)
     for (const action of actions) {
       expect(action.getAttribute('href')).toBe('/logs/new')
+      expect(action.textContent).toBe('Log activity')
+      expect(action.querySelector('svg')).toBeNull()
     }
     fireEvent.click(actions[0])
     expect(state.navigate).toHaveBeenCalledWith('/logs/new')
@@ -91,7 +93,7 @@ describe('New log header action', () => {
 
       await waitFor(() => {
         // Only the desktop copy remains; there is no duplicate in the drawer.
-        expect(screen.getAllByRole('link', { name: 'New log' })).toHaveLength(1)
+        expect(screen.getAllByRole('link', { name: 'Log activity' })).toHaveLength(1)
         expect(
           screen.getByRole('button', { name: 'Close main menu' }),
         ).toBeTruthy()
@@ -99,7 +101,7 @@ describe('New log header action', () => {
       expect(screen.getByRole('link', { name: 'Profile' })).toBeTruthy()
       fireEvent.click(screen.getByRole('button', { name: 'Close main menu' }))
       await waitFor(() =>
-        expect(screen.getAllByRole('link', { name: 'New log' })).toHaveLength(
+        expect(screen.getAllByRole('link', { name: 'Log activity' })).toHaveLength(
           2,
         ),
       )
@@ -109,17 +111,17 @@ describe('New log header action', () => {
   it('does not expose New log when signed out', () => {
     state.signedIn = false
     render(<Navigation />)
-    expect(screen.queryByRole('link', { name: 'New log' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Log activity' })).toBeNull()
     expect(screen.getByRole('link', { name: 'Log in' })).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Sign up' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Open main menu' }))
-    expect(screen.queryByRole('link', { name: 'New log' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Log activity' })).toBeNull()
   })
 
   it('does not navigate away from an in-progress New log form', () => {
     state.pathname = '/logs/new'
     render(<Navigation />)
-    const action = screen.getAllByRole('link', { name: 'New log' })[0]
+    const action = screen.getAllByRole('link', { name: 'Log activity' })[0]
     expect(action.getAttribute('aria-current')).toBe('page')
     fireEvent.click(action)
     expect(state.navigate).not.toHaveBeenCalled()

--- a/frontend/apps/webv2/app/ui/Navigation.tsx
+++ b/frontend/apps/webv2/app/ui/Navigation.tsx
@@ -10,7 +10,6 @@ import {
   UserIcon,
   WrenchScrewdriverIcon,
 } from '@heroicons/react/20/solid'
-import { PlusIcon } from '@heroicons/react/24/outline'
 import { useLogoutHandler, useSession, useUserRole } from '@app/common/session'
 import { useCurrentLocation } from '@app/common/hooks'
 import { routes } from '@app/common/routes'
@@ -33,9 +32,8 @@ export default function Navigation() {
     ? [
         {
           type: 'action',
-          label: 'New log',
+          label: 'Log activity',
           href: routes.logCreate(),
-          IconComponent: PlusIcon,
         },
         {
           type: 'dropdown',

--- a/frontend/apps/webv2/app/ui/Navigation.tsx
+++ b/frontend/apps/webv2/app/ui/Navigation.tsx
@@ -1,15 +1,16 @@
 import {
   Navbar,
+  NavigationActionProps,
   NavigationDropDownProps,
   NavigationLinkProps,
 } from 'ui/components/Navbar'
 import {
   ArrowRightOnRectangleIcon,
   Cog8ToothIcon,
-  PlusIcon,
   UserIcon,
   WrenchScrewdriverIcon,
 } from '@heroicons/react/20/solid'
+import { PlusIcon } from '@heroicons/react/24/outline'
 import { useLogoutHandler, useSession, useUserRole } from '@app/common/session'
 import { useCurrentLocation } from '@app/common/hooks'
 import { routes } from '@app/common/routes'
@@ -24,62 +25,65 @@ export default function Navigation() {
   const onLogout = useLogoutHandler([session])
   const currentUrl = useCurrentLocation()
 
-  const userNavigation: (NavigationLinkProps | NavigationDropDownProps)[] =
-    session
-      ? [
-          {
-            type: 'dropdown',
-            label: session.identity.traits.display_name ?? 'User',
-            links: [
-              {
-                label: 'Profile',
-                href: routes.userProfileStatistics(session.identity.id),
-                IconComponent: UserIcon,
-              },
-              {
-                label: 'New log',
-                href: routes.logCreate(),
-                IconComponent: PlusIcon,
-                divider: !isAdmin,
-                mobilePrimary: true,
-              },
-              ...(isAdmin
-                ? [
-                    {
-                      label: 'Admin',
-                      href: routes.admin(),
-                      IconComponent: WrenchScrewdriverIcon,
-                      divider: true,
-                    },
-                  ]
-                : []),
-              {
-                label: 'Account settings',
-                href: routes.authSettings(currentUrl),
-                IconComponent: Cog8ToothIcon,
-              },
-              {
-                label: 'Log out',
-                href: '#',
-                onClick: onLogout,
-                IconComponent: ArrowRightOnRectangleIcon,
-                mobileBottom: true,
-              },
-            ],
-          },
-        ]
-      : [
-          {
-            type: 'link',
-            label: 'Log in',
-            href: routes.authLogin(currentUrl),
-          },
-          {
-            type: 'link',
-            label: 'Sign up',
-            href: routes.authSignup(currentUrl),
-          },
-        ]
+  const userNavigation: (
+    | NavigationLinkProps
+    | NavigationDropDownProps
+    | NavigationActionProps
+  )[] = session
+    ? [
+        {
+          type: 'action',
+          label: 'New log',
+          href: routes.logCreate(),
+          IconComponent: PlusIcon,
+        },
+        {
+          type: 'dropdown',
+          label: session.identity.traits.display_name ?? 'User',
+          links: [
+            {
+              label: 'Profile',
+              href: routes.userProfileStatistics(session.identity.id),
+              IconComponent: UserIcon,
+              divider: !isAdmin,
+            },
+            ...(isAdmin
+              ? [
+                  {
+                    label: 'Admin',
+                    href: routes.admin(),
+                    IconComponent: WrenchScrewdriverIcon,
+                    divider: true,
+                  },
+                ]
+              : []),
+            {
+              label: 'Account settings',
+              href: routes.authSettings(currentUrl),
+              IconComponent: Cog8ToothIcon,
+            },
+            {
+              label: 'Log out',
+              href: '#',
+              onClick: onLogout,
+              IconComponent: ArrowRightOnRectangleIcon,
+              mobileBottom: true,
+            },
+          ],
+        },
+      ]
+    : [
+        {
+          type: 'link',
+          label: 'Log in',
+          href: routes.authLogin(currentUrl),
+        },
+        {
+          type: 'link',
+          label: 'Sign up',
+          href: routes.authSignup(currentUrl),
+        },
+      ]
 
   return (
     <Navbar

--- a/frontend/packages/ui/components/Navbar.tsx
+++ b/frontend/packages/ui/components/Navbar.tsx
@@ -40,7 +40,6 @@ export interface NavigationActionProps {
   type: 'action'
   label: string
   href: string
-  IconComponent: ComponentType<any>
 }
 
 interface Props {
@@ -289,11 +288,7 @@ export function Navbar({
   )
 }
 
-const NavigationAction = ({
-  label,
-  href,
-  IconComponent,
-}: NavigationActionProps) => {
+const NavigationAction = ({ label, href }: NavigationActionProps) => {
   const router = useRouter()
   const isCurrent = router.pathname === href
 
@@ -315,15 +310,9 @@ const NavigationAction = ({
           event.preventDefault()
         }
       }}
-      className="btn ghost group relative !h-11 !w-11 shrink-0 !p-0 text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      className="btn ghost !h-11 shrink-0 whitespace-nowrap px-2 text-secondary md:text-xs lg:text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
     >
-      <IconComponent className="!h-4 !w-4" aria-hidden="true" />
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute right-0 top-full z-50 mt-1 hidden whitespace-nowrap bg-secondary px-2 py-1 text-xs font-normal text-white group-hover:block group-focus-visible:block"
-      >
-        {label}
-      </span>
+      {label}
     </Link>
   )
 }
@@ -395,7 +384,7 @@ const DropDown = ({ label, links }: NavigationDropDownProps) => (
   <div className="">
     <Menu as="div" className="relative">
       <div>
-        <MenuButton className="max-w-32 lg:max-w-48 text-secondary hover:bg-secondary/5 focus:bg-secondary/5 text-xs px-2 py-1 lg:px-3 lg:py-2 lg:text-sm font-bold flex items-center justify-center">
+        <MenuButton className="max-w-24 lg:max-w-48 text-secondary hover:bg-secondary/5 focus:bg-secondary/5 text-xs px-2 py-1 lg:px-3 lg:py-2 lg:text-sm font-bold flex items-center justify-center">
           <span className="sr-only">Open navigation menu</span>
           <span className="truncate">{label}</span>
           <ChevronDownIcon

--- a/frontend/packages/ui/components/Navbar.tsx
+++ b/frontend/packages/ui/components/Navbar.tsx
@@ -310,7 +310,7 @@ const NavigationAction = ({ label, href }: NavigationActionProps) => {
           event.preventDefault()
         }
       }}
-      className="btn ghost !h-11 shrink-0 whitespace-nowrap px-2 text-secondary md:text-xs lg:text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      className="btn primary border-0 !h-11 md:!h-auto shrink-0 whitespace-nowrap px-2 py-1 lg:px-3 lg:py-2 md:text-xs lg:text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
     >
       {label}
     </Link>

--- a/frontend/packages/ui/components/Navbar.tsx
+++ b/frontend/packages/ui/components/Navbar.tsx
@@ -36,8 +36,19 @@ export interface NavigationLinkProps {
   current?: boolean
 }
 
+export interface NavigationActionProps {
+  type: 'action'
+  label: string
+  href: string
+  IconComponent: ComponentType<any>
+}
+
 interface Props {
-  navigation: (NavigationLinkProps | NavigationDropDownProps)[]
+  navigation: (
+    | NavigationLinkProps
+    | NavigationDropDownProps
+    | NavigationActionProps
+  )[]
   width?: string
   logoHref: string
   isLoading?: boolean
@@ -57,7 +68,7 @@ export function Navbar({
 
   return (
     <>
-      <div className="h-10 sm:h-16 absolute top-0 left-0 right-0 bg-white z-0"></div>
+      <div className="h-14 md:h-16 absolute top-0 left-0 right-0 bg-white z-0"></div>
       <Disclosure
         as="nav"
         className="sticky top-0 z-40 border-b border-black/10 bg-white shadow shadow-slate-500/10"
@@ -66,32 +77,25 @@ export function Navbar({
           <>
             <MobileScrollLock active={open} />
             <div className={`mx-auto ${width} px-2 sm:px-6 lg:px-8 z-10`}>
-              <div className="relative flex h-10 sm:h-16 items-center justify-between">
-                <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
-                  {/* Mobile menu button*/}
-                  <DisclosureButton className="inline-flex items-center justify-center p-2 text-secondary hover:bg-secondary/5 focus:bg-secondary/5 focus:outline-none focus:ring-3 focus:ring-inset focus:ring-secondary/20">
-                    <span className="sr-only">Open main menu</span>
-                    {open ? (
-                      <XMarkIcon className="block h-6 w-6" aria-hidden="true" />
-                    ) : (
-                      <Bars3Icon className="block h-6 w-6" aria-hidden="true" />
-                    )}
-                  </DisclosureButton>
-                </div>
-                <div className="flex flex-1 items-center justify-center sm:items-stretch sm:justify-between">
+              <div className="relative flex h-14 md:h-16 items-center justify-between">
+                <div className="flex min-w-0 flex-1 items-center justify-between">
                   <div className="flex flex-shrink-0 items-center">
                     <Link href={logoHref}>
-                      <span className="hidden sm:block">
+                      <span className="hidden md:block">
                         <Logo scale={0.8} priority />
                       </span>
-                      <span className="block sm:hidden">
-                        <Logo scale={0.5} priority />
+                      <span className="block md:hidden">
+                        <Logo scale={0.625} priority />
                       </span>
                     </Link>
                   </div>
-                  <div className="hidden sm:ml-6 sm:block">
-                    <div className="flex space-x-1 md:space-x-2">
+                  <div className="hidden md:ml-4 md:block">
+                    <div className="flex items-center space-x-1 lg:space-x-2">
                       {navigation.map(item => {
+                        if (item.type === 'action') {
+                          return <NavigationAction {...item} key={item.label} />
+                        }
+
                         if (item.type === 'dropdown') {
                           return <DropDown {...item} key={item.label} />
                         }
@@ -108,7 +112,7 @@ export function Navbar({
                                 isCurrent
                                   ? 'bg-secondary !text-white hover:bg-secondary/80'
                                   : 'text-secondary hover:bg-secondary/5 focus:bg-secondary/5',
-                                'reset text-xs px-2 py-1 md:px-3 md:py-2 md:text-sm font-bold inline-flex items-center justify-center',
+                                'reset text-xs px-2 py-1 lg:px-3 lg:py-2 lg:text-sm font-bold inline-flex items-center justify-center',
                               )}
                               aria-current={isCurrent ? 'page' : undefined}
                             >
@@ -120,11 +124,29 @@ export function Navbar({
                     </div>
                   </div>
                 </div>
+                <div className="ml-2 flex items-center gap-2 md:hidden">
+                  {!open &&
+                    navigation.map(item =>
+                      item.type === 'action' ? (
+                        <NavigationAction {...item} key={item.label} />
+                      ) : null,
+                    )}
+                  <DisclosureButton className="btn ghost flex !h-11 !w-11 items-center justify-center !p-0 text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+                    <span className="sr-only">
+                      {open ? 'Close main menu' : 'Open main menu'}
+                    </span>
+                    {open ? (
+                      <XMarkIcon className="!h-5 !w-5" aria-hidden="true" />
+                    ) : (
+                      <Bars3Icon className="!h-5 !w-5" aria-hidden="true" />
+                    )}
+                  </DisclosureButton>
+                </div>
               </div>
             </div>
 
-            <DisclosurePanel className="sm:hidden">
-              <div className="fixed inset-x-0 bottom-0 top-10 z-30 overflow-y-auto bg-white p-2 shadow-lg">
+            <DisclosurePanel className="md:hidden">
+              <div className="fixed inset-x-0 bottom-0 top-14 z-30 overflow-y-auto bg-white p-2 shadow-lg">
                 <div className="flex min-h-full flex-col">
                   <div className="space-y-1">
                     {navigation.map(item =>
@@ -267,6 +289,45 @@ export function Navbar({
   )
 }
 
+const NavigationAction = ({
+  label,
+  href,
+  IconComponent,
+}: NavigationActionProps) => {
+  const router = useRouter()
+  const isCurrent = router.pathname === href
+
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      aria-current={isCurrent ? 'page' : undefined}
+      onClick={event => {
+        // Keep an in-progress form intact when its header action is selected again.
+        if (
+          isCurrent &&
+          event.button === 0 &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
+          event.preventDefault()
+        }
+      }}
+      className="btn ghost group relative !h-11 !w-11 shrink-0 !p-0 text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+    >
+      <IconComponent className="!h-4 !w-4" aria-hidden="true" />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute right-0 top-full z-50 mt-1 hidden whitespace-nowrap bg-secondary px-2 py-1 text-xs font-normal text-white group-hover:block group-focus-visible:block"
+      >
+        {label}
+      </span>
+    </Link>
+  )
+}
+
 const MobileScrollLock = ({ active }: { active: boolean }) => {
   useEffect(() => {
     if (!active) return
@@ -334,11 +395,11 @@ const DropDown = ({ label, links }: NavigationDropDownProps) => (
   <div className="">
     <Menu as="div" className="relative">
       <div>
-        <MenuButton className="text-secondary hover:bg-secondary/5 focus:bg-secondary/5 text-xs px-2 py-1 md:px-3 md:py-2 md:text-sm font-bold flex items-center justify-center">
+        <MenuButton className="max-w-32 lg:max-w-48 text-secondary hover:bg-secondary/5 focus:bg-secondary/5 text-xs px-2 py-1 lg:px-3 lg:py-2 lg:text-sm font-bold flex items-center justify-center">
           <span className="sr-only">Open navigation menu</span>
-          {label}
+          <span className="truncate">{label}</span>
           <ChevronDownIcon
-            className="ml-2 h-4 w-3 md:h-5 md:w-4"
+            className="ml-2 h-4 w-3 shrink-0 lg:h-5 lg:w-4"
             aria-hidden="true"
           />
         </MenuButton>

--- a/frontend/packages/ui/tests/navbar-mobile.test.mjs
+++ b/frontend/packages/ui/tests/navbar-mobile.test.mjs
@@ -12,7 +12,7 @@ const actionMenuSource = await readFile(
 )
 
 const mobilePanelStart = navbarSource.indexOf(
-  '<DisclosurePanel className="sm:hidden">',
+  '<DisclosurePanel className="md:hidden">',
 )
 const mobilePanelEnd = navbarSource.indexOf(
   '</DisclosurePanel>',


### PR DESCRIPTION
Signed-in readers can now open the New log page directly from a text-only purple **Log activity** button in the header. On desktop it sits immediately before the user menu. On mobile it sits beside the menu button on the right, hides while the menu is open, and returns when the menu closes.


The visible label replaces the old dropdown/drawer entry. The button matches adjacent desktop navigation items exactly: 24 px tall at tablet widths and 36 px on large screens, with identical text size and padding. On mobile it matches the menu control’s 44 px height. It has a keyboard focus indicator, and preserves an in-progress log form when selected again. Signed-out users retain Log in and Sign up.

The shared navbar uses a 56 px mobile header with the logo on the left, switches to desktop navigation at 768 px, and truncates long desktop usernames to leave room for the action. These shared layout changes also apply to the auth app and styleguide; Log activity is configured only in webv2.

[Current design in Draft, version 5](https://draft.apps.lab/documents/tadoku-new-log-header-proposals-2026-09.html?version=5)

Validation:

- Webv2 typecheck and lint passed.
- All five navigation behavior cases and eight shared UI tests passed, including assertions for the visible label and absence of an icon.
- Full `pnpm build` passed across the frontend workspace after the final styling change.
- Browser checks against the production frontend build with mocked auth/API responses passed at 320, 390, 768, 1024, and 1440 px. Verified purple fill and white text, no icons or header overflow, and exact height/typography/padding parity with adjacent desktop items and height parity with the mobile menu control. Mobile hide/restore behavior was verified in the preceding browser check.

A separate prerequisite commit fixes a pre-existing async `act` callback type error in the feature-flag test so the frontend typecheck/build can pass.

**Posted by GPT-6**
